### PR TITLE
add pause to surface_snapshots

### DIFF
--- a/scripts/surface_snapshots.py
+++ b/scripts/surface_snapshots.py
@@ -186,7 +186,7 @@ def save_view_panes(b, sign, hemi):
 
         # Set the view and screenshot
         b.show_view(view, distance=330)
-        pause(0.2)  # pause for show_view
+        sleep(0.2)  # pause for show_view
         image_panes.append(b.screenshot())
 
     # Stitch the images together and return the array


### PR DESCRIPTION
Added a pause after show_view to give time for view to update before snapshot taken; otherwise ventral view doesn't appear and stat bar not visible
