### PR TITLE
Fix bug in FNIRT workflow datasink

### DIFF
--- a/doc/release/v0.0.4.txt
+++ b/doc/release/v0.0.4.txt
@@ -12,6 +12,13 @@ Mixed effects workflow
 
 - Fixed a bug where the analysis mask was getting smoothed on the surface.
 
+FNIRT-based normalization workflow
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- Fixed a bug where the outputs of FNIRT were not properly renamed and thus
+  were not correctly picked up by the registration stage of the functional
+  pipeline.
+
 Surface snapshots script
 ~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/lyman/workflows/anatwarp.py
+++ b/lyman/workflows/anatwarp.py
@@ -60,8 +60,9 @@ def create_fsl_workflow(data_dir=None, subjects=None, name="fslwarp"):
                          name="subjectsource")
 
     # Grab recon-all outputs
+    head_image = "T1"
     templates = dict(aseg="{subject_id}/mri/aparc+aseg.mgz",
-                     head="{subject_id}/mri/T1.mgz")
+                     head="{subject_id}/mri/" + head_image + ".mgz")
     datasource = Node(SelectFiles(templates,
                                   base_directory=data_dir),
                       "datasource")
@@ -108,13 +109,13 @@ def create_fsl_workflow(data_dir=None, subjects=None, name="fslwarp"):
     warpreport = Node(WarpReport(), "warpreport")
 
     # Save relevant files to the data directory
+    fnirt_subs = [(head_image + "_out_masked_flirt.mat", "affine.mat"),
+                  (head_image + "_out_fieldwarp", "warpfield"),
+                  (head_image + "_out_masked", "brain"),
+                  (head_image + "_out", "T1")]
     datasink = Node(DataSink(base_directory=data_dir,
                              parameterization=False,
-                             substitutions=[
-                                 ("orig_out_masked_flirt.mat", "affine.mat"),
-                                 ("orig_out_fieldwarp", "warpfield"),
-                                 ("orig_out_masked", "brain"),
-                                 ("orig_out", "T1")]),
+                             substitutions=fnirt_subs),
                     "datasink")
 
     # Define and connect the workflow


### PR DESCRIPTION
This fixes the substitutions in the FNIRT workflow datasink so that the outputs are renamed correctly (and thus can be seen by the registration workflow data grabber).

Fixes #47 
