### PR TITLE
Fix for FSL highpass filter changes

### DIFF
--- a/doc/release/v0.0.5.txt
+++ b/doc/release/v0.0.5.txt
@@ -1,0 +1,16 @@
+
+v0.0.5 (November 7, 2014)
+-------------------------
+
+Preprocessing workflow
+~~~~~~~~~~~~~~~~~~~~~~
+
+- Added a workaround some changes in later versions of FSL
+  that now return a de-meaned timeseries from the highpass filter.
+  In FEAT, the mean is replaced, and the rest of the processing carries
+  on as usual. Because I don't want to break compatability with older
+  versions of FSL, this adds back in the mean but only if it looks
+  like the filtered timeseries has been de-meaned. **Note**: This uses
+  a simple heuristic, which may not be robust in all cases, so it is
+  important to check that the signal-to-noise maps make sense if you are
+  doing something that expects a nonzero timeseries mean.

--- a/doc/releases.rst
+++ b/doc/releases.rst
@@ -1,6 +1,8 @@
 Release notes
 =============
 
+.. include:: release/v0.0.5.txt
+
 .. include:: release/v0.0.4.txt
 
 .. include:: release/v0.0.3.txt


### PR DESCRIPTION
This works around some changes in later version of FSL (as of 11/2014)
that return a de-meaned timeseries from the FSL highpass filter.
In FEAT, the mean is replaced, and the rest of the processing carries
on as usual. Because I don't want to break compatability with older
versions of FSL, this adds back in the mean but only if it looks
like the filtered timeseries has been de-meaned.
