### PR TITLE
Add crash_dir variable to project level parameterization.

### DIFF
--- a/doc/release/v0.0.7.txt
+++ b/doc/release/v0.0.7.txt
@@ -6,6 +6,16 @@ Execution
 ~~~~~~~~~
 
 - Added the option to submit jobs using slurm.
+- Added the ``crash_dir`` parameter at the project level (i.e. it will be
+  defined when you run ``setup_project.py`` and will be stored in
+  ``$LYMAN_DIR/project.py``). This allows you to specify where debugging
+  information will be written if something goes wrong during workflow
+  execution. The previous approach to selecting where crash files would be
+  written was not robust in all execution contexts. **Important:** if you
+  upgrade to this version and try to rerun something in an existing project,
+  you will get an error.  This can be avoided by defining ``crash_dir`` in your
+  project file. These files are usually only transiently useful, so the default
+  location for new projects is ``/tmp/nipype-$USER-crashes``.
 
 Registration workflow
 ~~~~~~~~~~~~~~~~~~~~~~

--- a/lyman/frontend.py
+++ b/lyman/frontend.py
@@ -18,7 +18,7 @@ def gather_project_info():
         project = imp.load_source("project", proj_file)
 
     project_dict = dict()
-    for dir in ["data", "analysis", "working"]:
+    for dir in ["data", "analysis", "working", "crash"]:
         path = op.abspath(op.join(lyman_dir, getattr(project, dir + "_dir")))
         project_dict[dir + "_dir"] = path
     project_dict["default_exp"] = project.default_exp

--- a/scripts/run_fmri.py
+++ b/scripts/run_fmri.py
@@ -51,11 +51,7 @@ def main(arglist):
     data_dir = project["data_dir"]
     analysis_dir = op.join(project["analysis_dir"], exp_name)
     working_dir = op.join(project["working_dir"], exp_name)
-
-    # Just stick crashdumps in a unique /tmp directory
-    nipype.config.set("execution", "crashdump_dir",
-                      "/tmp/%s-nipype_crashes-%d" % (os.getlogin(),
-                                                     time.time()))
+    nipype.config.set("execution", "crashdump_dir", project["crash_dir"])
 
     # Create symlinks to the preproc directory for altmodels
     if not op.exists(analysis_dir):

--- a/scripts/run_group.py
+++ b/scripts/run_group.py
@@ -44,9 +44,7 @@ def main(arglist):
     # Set roots of output storage
     anal_dir_base = op.join(project["analysis_dir"], exp_name)
     work_dir_base = op.join(project["working_dir"], exp_name)
-    nipype.config.set("execution", "crashdump_dir",
-                      "/tmp/%s-nipype_crashes-%d" % (os.getlogin(),
-                                                     time.time()))
+    nipype.config.set("execution", "crashdump_dir", project["crash_dir"])
 
     # Subject source (no iterables here)
     subject_list = lyman.determine_subjects(args.subjects)

--- a/scripts/run_warp.py
+++ b/scripts/run_warp.py
@@ -59,10 +59,8 @@ def main(arglist):
     normalize = wf_func(project["data_dir"], subject_list)
     normalize.base_dir = project["working_dir"]
     
-    # Put crashdumps in a unique /tmp directory
-    nipype.config.set("execution", "crashdump_dir",
-                      "/tmp/%s-nipype_crashes-%d" % (os.getlogin(),
-                                                     time.time()))
+    # Put crashdumps somewhere out of the way
+    nipype.config.set("execution", "crashdump_dir", project["crash_dir"])
 
     # Execute the workflow
     lyman.run_workflow(normalize, args=args)

--- a/scripts/setup_project.py
+++ b/scripts/setup_project.py
@@ -118,6 +118,9 @@ analysis_dir = '%(analysis_dir)s'
 # Working directory is where data lives during workflow execution
 working_dir = '%(working_dir)s'
 
+# Crash directory is where debugging info will be written if things go wrong
+crash_dir = '%(crash_dir)s'
+
 # Set this to True to remove the working directory after each excecution
 rm_working_dir = %(rm_work_dir)s
 
@@ -256,6 +259,10 @@ Please use relative paths.
     
     do_prompt(d, "working_dir", "Working tree path", 
               op.join(d['analysis_dir'], 'workingdir'), is_path)
+
+    crash_stem = "niypype-" + os.environ.get("LOGNAME", "-") + "-crashes"
+    do_prompt(d, "crash_dir", "Crashdump path",
+              op.join("/tmp", crash_stem))
 
     do_prompt(d, "rm_work_dir", "Remove working directory after execution? (Y/n)",
               "y", boolean)


### PR DESCRIPTION
This allows you to specify where debugging information will be written if
something goes wrong during workflow execution. The previous approach to
selecting where crash files would be written was not robust in all execution
contexts.

**Important:** if you upgrade to this version and try to rerun
something in an existing project, you will get an error.  This can be avoided
by defining ``crash_dir`` in your project file. These files are usually only
transiently useful, so the default location for new projects is
``/tmp/nipype-$USER-crashes``.

Closes #46