### PR TITLE
WIP Add FIR Model Setup Options

### DIFF
--- a/lyman/workflows/model.py
+++ b/lyman/workflows/model.py
@@ -21,6 +21,7 @@ import lyman
 from lyman.tools import ManyOutFiles, SaveParameters, nii_to_png
 import inspect
 
+
 def create_timeseries_model_workflow(name="model", exp_info=None):
 
     # Default experiment parameters for generating graph image, testing, etc.


### PR DESCRIPTION
Hi Michael, 

This small patch uses the FIR model already inside of Moss, and seems to be working for me, but I'm still testing. Any thoughts?

I'll add docs about hrf_params - we need at least nbasis I think. This edits the hrf class to take only kwargs, since some of the DoubleGamma args raise an error for the FIR hrf class. 

Best,
Erik