### PR TITLE
Improve the anatomy snapshots script

### DIFF
--- a/doc/release/v0.0.8.txt
+++ b/doc/release/v0.0.8.txt
@@ -11,6 +11,25 @@ Model workflow
   to nipype 0.10. The main advantage of upgrading should be increased memory
   performance in the model estimation.
 
+Anatomy snapshots script
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+- Added plots of the native white and pial surfaces
+- Surface plots are now saved in one image file with all views,
+  and the subplot size is automatically inferred to maximize the
+  usage of space
+- Added ventral views to the surface images
+- Changed how the surface normalization is summarized. The new
+  visualization highlights vertices where the binarized curvature
+  value is different between the normalized subject and template
+- Remove the "-noclose" option, as better ways to avoid the problem
+  that motivated it have been identified.
+
+Note that there are corresponding changes in ziegler that are needed to
+properly view the new images, and there isn't backwards compatability
+with the old outputs. This script can be rerun on older lyman analyses
+ithout affecting anything.
+
 Mixed-effects workflow
 ~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
- Added plots of the native white and pial surfaces

![pial_surface](https://cloud.githubusercontent.com/assets/315810/8485497/dd51c420-20b2-11e5-9757-5f76d9cae836.png)

- Surface plots are now saved in one image file with all views,
  and the subplot size is automatically inferred to maximize the
  usage of space
- Added ventral views to the surface images
- Changed how the surface normalization is summarized. The new
  visualization highlights vertices where the binarized curvature
  value is different between the normalized subject and template

![surface_registration](https://cloud.githubusercontent.com/assets/315810/8485480/c2e95ef4-20b2-11e5-9ffd-d88b0d18c790.png)

- Remove the "-noclose" option, as better ways to avoid the problem
  that motivated it have been identified and removing it cleans up the code

Note that there are corresponding changes in ziegler that are needed to
properly view the new images, and there isn't backwards compatibility
with the old outputs. This script can be rerun on older lyman analyses
without affecting anything.