### PR TITLE
Allow for conditions with no events

### DIFF
--- a/doc/experiments.rst
+++ b/doc/experiments.rst
@@ -140,9 +140,8 @@ Model Parameters
 
    confound_pca
     A boolean specifying whether the dimensionality of the confound matrix
-    (currently just the 6 motion parameters) should be reduced using PCA.
-    The resulting dimensionality is automatically inferred using an MLE
-    approach.
+    (currently just the 6 motion parameters) should be reduced using PCA
+    to include dimensions explaining 99% of the variance.
 
    hrf_params
     A dictionary with keyword arguments for the HRF model class.
@@ -194,20 +193,20 @@ Group Analysis Parameters
 
    sampling_range
     A 3-tuple of floats where where to start, stop and the size of the step
-    (all in `sampling_units`) when projecting data onto the white surface. This
+    (all in ``sampling_units``) when projecting data onto the white surface. This
     only applies to group analysis in fsaverage space.
 
    sampling_units
     A string that is either "frac" or "mm" that makes up part of the
     specification for projecting results onto the surface manifold (it
-    determines the units of the `sampling_range` paramters`). This only applies
+    determines the units of the ``sampling_range`` paramters). This only applies
     to group analysis in fsaverage space.
 
    sampling_method
     A string that is either "average", "max", or "point" that makes up part of
     the specification for projecting results onto the surface manifold (it
-    determines how to summarize the samples obtained using `sampling_range` and
-    `sampling_method` into a single value at each verex). This only applies to
+    determines how to summarize the samples obtained using ``sampling_range`` and
+    ``sampling_method`` into a single value at each verex). This only applies to
     group analysis in fsaverage space.
 
    surf_corr_sign

--- a/doc/release/v0.0.8.txt
+++ b/doc/release/v0.0.8.txt
@@ -16,32 +16,41 @@ Registration workflow
 
 - Added the ability to do cross-experiment registration, e.g. in the case where
   you have a functional localizer. This is accomplished through the ``-regexp``
-  flag in ``run_fmri.py``. For example, the cmdline
-  ``run_fmri.py -exp A -regexp B -regspace epi -timeseries`` will combine
-  the func-to-anat matrices from experiment A and the anat-to-func
-  matrix from the first run of experiment B, placing the experiment A
-  files in a common space with experiment B files.
+  flag in ``run_fmri.py``. For example, the cmdline ``run_fmri.py -exp A
+  -regexp B -regspace epi -timeseries`` will combine the func-to-anat matrices
+  from experiment A and the anat-to-func matrix from the first run of
+  experiment B, placing the experiment A files in a common space with
+  experiment B files.
+
+Fixed-effects workflow
+~~~~~~~~~~~~~~~~~~~~~~
+
+- The fixed effects analysis no longer crashes when a subject did not have any
+  observations for an event.
+
+Mixed-effects workflow
+~~~~~~~~~~~~~~~~~~~~~~
+
+- The mixed effects workflow now excludes empty images, allowing you to run it
+  on a group where some subjects did not have any observations for a specific
+  event/contrast.
+- Updated the mixed effects boxplot code for compatibility with seaborn 0.6.
 
 Anatomy snapshots script
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
 - Added plots of the native white and pial surfaces
-- Surface plots are now saved in one image file with all views,
-  and the subplot size is automatically inferred to maximize the
-  usage of space
+- Surface plots are now saved in one image file with all views, and the subplot
+  size is automatically inferred to maximize the usage of space
 - Added ventral views to the surface images
-- Changed how the surface normalization is summarized. The new
-  visualization highlights vertices where the binarized curvature
-  value is different between the normalized subject and template
-- Remove the "-noclose" option, as better ways to avoid the problem
-  that motivated it have been identified.
+- Changed how the surface normalization is summarized. The new visualization
+  highlights vertices where the binarized curvature value is different between
+  the normalized subject and template
+- Remove the "-noclose" option, as better ways to avoid the problem that
+  motivated it have been identified.
 
 Note that there are corresponding changes in ziegler that are needed to
 properly view the new images, and there isn't backwards compatability
 with the old outputs. This script can be rerun on older lyman analyses
-ithout affecting anything.
+without affecting any results.
 
-Mixed-effects workflow
-~~~~~~~~~~~~~~~~~~~~~~
-
-- Updated the mixed effects boxplot code for compatibility with seaborn 0.6.

--- a/lyman/workflows/fixedfx.py
+++ b/lyman/workflows/fixedfx.py
@@ -155,6 +155,10 @@ class FFXModel(BaseInterface):
             good_vs = [not np.allclose(d, 0) for d in vs]
             good = np.all([good_cs, good_vs], axis=0)
 
+            # Handle the case where no events occured for this contrast
+            if not good.any():
+                good = np.ones(len(cs), bool)
+
             # Concatenate the cope and varcope data, save only the good frames
             c_data = np.concatenate(cs, axis=-1)[:, :, :, good]
             v_data = np.concatenate(vs, axis=-1)[:, :, :, good]

--- a/lyman/workflows/tests/test_mixedfx.py
+++ b/lyman/workflows/tests/test_mixedfx.py
@@ -48,3 +48,9 @@ class TestGroupMerge(object):
         out_data = out_img.get_data()
         in_data_reordered = np.asarray(in_data).transpose(1, 2, 3, 0)
         npt.assert_array_equal(in_data_reordered, out_data)
+
+        merge = mixedfx.MergeAcrossSubjects()
+        good_indices = range(8)
+        out_img = merge._merge_subject_images(in_imgs, good_indices)
+        nt.assert_is_instance(out_img, nib.Nifti1Image)
+        nt.assert_equal(out_img.shape, (91, 109, 91, 8))


### PR DESCRIPTION
This involves changes to the fixed effects and group level workflows

- At the fixed effects workflow level, if all images are empty,
  then they are all used. This means the fixed effects outputs will
  be meaningless, but obviously so. This means the fixed effects
  workflow will no longer crash when all images for a specific contrast
  are empty.
- At the group level, exclude subjects with empty varcope images for
  a specific contrast. This allows the empty fixed effects outputs not
  to influence the group-level analyses.

Closes #57 