### PR TITLE
Add ability to correct susceptibility-induced distortions

### DIFF
--- a/doc/experiments.rst
+++ b/doc/experiments.rst
@@ -50,6 +50,13 @@ Preprocessing Parameters
     (although you specify only one whole-brain file).  If you don't have such
     an image, just leave this out of the experiment file.
 
+   fieldmp_template
+    A template string, like the source template, that identifies images that
+    can be used to compute a map of distortions in the field. This isn't
+    actually meant to be a traditional "fieldmap" image, but rather multiple
+    images with the same slice prescription as the function runs but with
+    one or more images where the phase encoding direction is reversed.
+
    n_runs
     An integer with the number of functional runs in the experiment.
 
@@ -59,6 +66,12 @@ Preprocessing Parameters
    frames_to_toss
     An integer with the number of frames to trim from the beginning of the
     timeseries.
+
+   fieldmap_pe
+    Directions of phase encoding directions in the fieldmap images, if they
+    exist. For example, ``["y", "-y"]`` means that the fieldmap images have
+    two frames where the first has normal phase encoding on the y axis and
+    the second has reversed phase encoding also on the y axis.
 
    temporal_interp
     A boolean that specifies whether slice-time correction should be performed.

--- a/doc/experiments.rst
+++ b/doc/experiments.rst
@@ -50,7 +50,7 @@ Preprocessing Parameters
     (although you specify only one whole-brain file).  If you don't have such
     an image, just leave this out of the experiment file.
 
-   fieldmp_template
+   fieldmap_template
     A template string, like the source template, that identifies images that
     can be used to compute a map of distortions in the field. This isn't
     actually meant to be a traditional "fieldmap" image, but rather multiple

--- a/doc/release/v0.0.9.txt
+++ b/doc/release/v0.0.9.txt
@@ -1,0 +1,13 @@
+
+v 0.0.9 (Unreleased)
+--------------------
+
+Preproc workflow
+~~~~~~~~~~~~~~~~
+
+- Added the ability to supply fieldmap images that can be used to unwarp
+  distortions caused by dropout regions. This uses FSL's ``topup`` and
+  ``applytopup`` utilities. The images you should provide aren't actually
+  traditional "fieldmaps", but rather images with normal and reversed phase
+  encoding directions, from which a map of the distortions can be computed.
+

--- a/lyman/frontend.py
+++ b/lyman/frontend.py
@@ -103,7 +103,7 @@ def default_experiment_parameters():
 
         TR=2,
         frames_to_toss=0,
-        fieldmap_pe=("y", "-y"),
+        fieldmap_pe=("y", "y-"),
         temporal_interp=False,
         interleaved=True,
         coreg_init="fsl",

--- a/lyman/frontend.py
+++ b/lyman/frontend.py
@@ -72,6 +72,7 @@ def gather_experiment_info(exp_name=None, altmodel=None):
     # Save the __doc__ attribute to the dict
     exp_dict["comments"] = "" if exp.__doc__ is None else exp.__doc__
     if altmodel is not None:
+        exp_dict["comments"] += "\n"
         exp_dict["comments"] += "" if alt.__doc__ is None else alt.__doc__
 
     # Check if it looks like this is a partial FOV acquisition
@@ -97,10 +98,12 @@ def default_experiment_parameters():
 
         source_template="",
         whole_brain_template="",
+        fieldmap_template="",
         n_runs=0,
 
         TR=2,
         frames_to_toss=0,
+        fieldmap_pe=("y", "-y"),
         temporal_interp=False,
         interleaved=True,
         coreg_init="fsl",

--- a/lyman/workflows/preproc.py
+++ b/lyman/workflows/preproc.py
@@ -219,7 +219,7 @@ def create_unwarp_workflow(name="unwarp", fieldmap_pe=("y", "y-")):
 
     # Unwarp the timeseries
     applytopup = MapNode(fsl.ApplyTOPUP(in_index=[1]),
-                         ["timeseries",
+                         ["in_files",
                           "in_topup_fieldcoef",
                           "in_topup_movpar",
                           "encoding_file"],
@@ -234,7 +234,7 @@ def create_unwarp_workflow(name="unwarp", fieldmap_pe=("y", "y-")):
         (inputnode, topup,
             [("fieldmap", "in_file")]),
         (inputnode, applytopup,
-            [("timeseries", "in_file")]),
+            [("timeseries", "in_files")]),
         (topup, applytopup,
             [("out_fieldcoef", "in_topup_fieldcoef"),
              ("out_movpar", "in_topup_movpar"),

--- a/lyman/workflows/preproc.py
+++ b/lyman/workflows/preproc.py
@@ -226,7 +226,7 @@ def create_unwarp_workflow(name="unwarp", fieldmap_pe=("y", "y-")):
                          "applytopup")
 
     # Define the outputs
-    outputnode = Node(IdentityInterface(["timeseries"], "outputs"))
+    outputnode = Node(IdentityInterface(["timeseries"]), "outputs")
 
     # Define and connect the workflow
     unwarp = Workflow(name)

--- a/lyman/workflows/preproc.py
+++ b/lyman/workflows/preproc.py
@@ -635,6 +635,8 @@ class UnwarpReport(BaseInterface):
         f.savefig("unwarping.png", facecolor="black", edgecolor="black")
         plt.close(f)
 
+        return runtime
+
     def combine_frames(self, img):
 
         # Find a value to loosely segment the brain

--- a/lyman/workflows/preproc.py
+++ b/lyman/workflows/preproc.py
@@ -203,7 +203,7 @@ def create_preprocessing_workflow(name="preproc", exp_info=None):
 # =========================================================================== #
 
 
-def create_unwarp_workflow(name="unwarp", fieldmap_pe=("y", "-y")):
+def create_unwarp_workflow(name="unwarp", fieldmap_pe=("y", "y-")):
     """Unwarp functional timeseries using reverse phase-blipped images."""
     inputnode = Node(IdentityInterface(["timeseries", "fieldmap"]), "inputs")
 

--- a/lyman/workflows/preproc.py
+++ b/lyman/workflows/preproc.py
@@ -619,7 +619,7 @@ class UnwarpReport(BaseInterface):
         cmap = mpl.colors.ListedColormap(["black", "#d65f5f", "white"])
 
         # Initialize the figure
-        f, axes = plt.subplots(1, 2, figsize=(9, 4),
+        f, axes = plt.subplots(1, 2, figsize=(9, 2.75),
                                facecolor="black", edgecolor="black")
 
         for ax, fname in zip(axes, [self.inputs.orig_file,

--- a/lyman/workflows/preproc.py
+++ b/lyman/workflows/preproc.py
@@ -204,7 +204,7 @@ def create_preprocessing_workflow(name="preproc", exp_info=None):
     if bool(exp_info["fieldmap_template"]):
         preproc.connect([
             (unwarp, outputnode,
-                [("report", "unwarp_report")]),
+                [("outputs.report", "unwarp_report")]),
         ])
 
     return preproc, inputnode, outputnode

--- a/lyman/workflows/preproc.py
+++ b/lyman/workflows/preproc.py
@@ -218,7 +218,7 @@ def create_unwarp_workflow(name="unwarp", fieldmap_pe=("y", "y-")):
                     ["in_file"], "topup")
 
     # Unwarp the timeseries
-    applytopup = MapNode(fsl.ApplyTOPUP(in_index=[1]),
+    applytopup = MapNode(fsl.ApplyTOPUP(method="jac", in_index=[1]),
                          ["in_files",
                           "in_topup_fieldcoef",
                           "in_topup_movpar",

--- a/lyman/workflows/preproc.py
+++ b/lyman/workflows/preproc.py
@@ -670,10 +670,9 @@ class ExtractRealignmentTarget(BaseInterface):
 
         # Load the input timeseries
         img = nib.load(self.inputs.in_file)
-        data = img.get_data()
 
         # Extract the target volume
-        targ = self.extract_target(data)
+        targ = self.extract_target(img)
 
         # Save a new 3D image
         targ_img = nib.Nifti1Image(targ,
@@ -683,11 +682,11 @@ class ExtractRealignmentTarget(BaseInterface):
 
         return runtime
 
-    def extract_target(self, data):
+    def extract_target(self, img):
         """Return a 3D array with data from the middle TR."""
-        middle_vol = data.shape[-1] // 2
-        targ = np.empty(data.shape[:-1])
-        targ[:] = data[..., middle_vol]
+        middle_vol = img.shape[-1] // 2
+        targ = np.empty(img.shape[:-1])
+        targ[:] = img.dataobj[..., middle_vol]
 
         return targ
 

--- a/lyman/workflows/preproc.py
+++ b/lyman/workflows/preproc.py
@@ -653,7 +653,7 @@ class UnwarpReport(BaseInterface):
 
         # Make an image showing overlap and divergence
         c = np.zeros_like(a, int)
-        c[a ^ b] = 2
+        c[a ^ b] = 1
         c[a & b] = 2
 
         return c

--- a/lyman/workflows/tests/test_preproc.py
+++ b/lyman/workflows/tests/test_preproc.py
@@ -1,6 +1,7 @@
 import numpy as np
 import nose.tools as nt
 import numpy.testing as npt
+import nibabel as nib
 from .. import preproc
 
 
@@ -24,8 +25,9 @@ def test_extract_realignment_target():
     for ntp in [20, 21]:
         index = np.arange(ntp)[None, None, None, :]
         data = np.ones((45, 45, 30, ntp)) * index
+        img = nib.Nifti1Image(data, np.eye(4))
 
-        targ = extractor.extract_target(data)
+        targ = extractor.extract_target(img)
         nt.assert_equal(np.asscalar(np.unique(targ)), ntp // 2)
 
 

--- a/scripts/run_fmri.py
+++ b/scripts/run_fmri.py
@@ -83,7 +83,9 @@ def main(arglist):
     # Collect raw nifti data
     preproc_templates = dict(timeseries=exp["source_template"])
     if exp["partial_brain"]:
-        preproc_templates["whole_brain_template"] = exp["whole_brain_template"]
+        preproc_templates["whole_brain"] = exp["whole_brain_template"]
+    if exp["fieldmap_template"]:
+        preproc_templates["fieldmap"] = exp["fieldmap_template"]
 
     preproc_source = Node(SelectFiles(preproc_templates,
                                       base_directory=project["data_dir"]),


### PR DESCRIPTION
Added the ability to supply fieldmap images that can be used to unwarp distortions caused by dropout regions. This uses FSL's ``topup`` and ``applytopup`` utilities. The images you should provide aren't actually traditional "fieldmaps", but rather images with normal and reversed phase encoding directions, 
from which a map of the distortions can be computed.

There are new experiment parameters, `fieldmap_template` and `fieldmap_pe`. It isa assumed that a fieldmap image exists for each run and that the sorted list of timeseries images and fieldmap images should correspond.

This produces a report image that looks like this:

![unwarping](https://cloud.githubusercontent.com/assets/315810/9640458/902ede82-5166-11e5-83d5-796ee4a8b6f6.png)

The image is created by thresholding the two images with different phase encode directions before and after correction. Red pixels show where the resulting binary mask is present for only one direction, i.e. a good correction will reduce the amount of disagreement. This representation requires an update to ziegler, and it may change in the future if I think of something better.