### PR TITLE
Increased flexibility for confound removal during model fitting.

### DIFF
--- a/doc/experiments.rst
+++ b/doc/experiments.rst
@@ -109,6 +109,12 @@ Preprocessing Parameters
     total displacement (in mm) relative to the previous frame exceeds this
     number will be excluded from the model.
 
+   wm_components
+    Number of principle components to use when extracting nuisance timeseries
+    data from deep white matter voxels. This provides additional confound
+    information that can be added during the model fitting (using the
+    ``confound_sources`` variable).
+
    smooth_fwhm
     A float with the smoothing kernel size for the volume-based SUSAN smoothing.
     Note that an unsmoothed version of the timeseries is always produced.
@@ -151,10 +157,24 @@ Model Parameters
     model for each explanatory variable (these are considered regressors of
     no interest).
 
+   confound_sources
+    A list of strings that can include ``"motion"``, ``"wm"``, and ``"brain"``.
+    This specifies what information should be added to the "confounds"
+    component of the design matrix. ``"motion"`` are the six motion parameters
+    obtained during realignment, ``"wm"`` are timeseries data from deep white
+    matter with dimensionality reduced using PCA (controlled by the
+    ``nuisance_components`` variable), and ``"brain"`` is the mean timecourse
+    over the whole brain mask.
+
+   remove_artifacts
+    Boolean specifying whether indicator vectors should be added to the
+    design matrix to identify (and thus remove) frames that are determined
+    during preprocessing to contain artifacts.
+
    confound_pca
     A boolean specifying whether the dimensionality of the confound matrix
-    (currently just the 6 motion parameters) should be reduced using PCA
-    to include dimensions explaining 99% of the variance.
+    should be reduced using PCA to include dimensions explaining 99% of the
+    variance.
 
    hrf_params
     A dictionary with keyword arguments for the HRF model class.

--- a/doc/release/v0.0.9.txt
+++ b/doc/release/v0.0.9.txt
@@ -6,14 +6,23 @@ Preproc workflow
 ~~~~~~~~~~~~~~~~
 
 - Added the ability to supply fieldmap images that can be used to unwarp
-  distortions caused by dropout regions. This uses FSL's ``topup`` and
+  distortions caused by susceptibility regions. This uses FSL's ``topup`` and
   ``applytopup`` utilities. The images you should provide aren't actually
   traditional "fieldmaps", but rather images with normal and reversed phase
   encoding directions, from which a map of the distortions can be computed.
+  See the new experiment option ``fieldmap_template``.
 
 
 Model workflow
 ~~~~~~~~~~~~~~
+
+- Added the ability to include additional nuisance variables in the model.
+  This can now include eigenvariates of deep white matter timeseries and the
+  mean signal from across the whole brain. This involves the new experiment
+  options ``wm_components`` and ``confound_sources``.
+
+- Made the inclusion of artifact indicator vectors in the design matrix optional.
+  See the new experiment option ``remove_artifacts``.
 
 - Made some changes to the model summary node to use memory more efficiently.
   The model summary code should now use a similar amount of memory as the

--- a/doc/release/v0.0.9.txt
+++ b/doc/release/v0.0.9.txt
@@ -19,7 +19,9 @@ Model workflow
 - Added the ability to include additional nuisance variables in the model.
   This can now include eigenvariates of deep white matter timeseries and the
   mean signal from across the whole brain. This involves the new experiment
-  options ``wm_components`` and ``confound_sources``.
+  options ``wm_components`` and ``confound_sources``. This change requires that
+  you rerun the preproc workflow before running the model workflow after updating
+  lyman.
 
 - Made the inclusion of artifact indicator vectors in the design matrix optional.
   See the new experiment option ``remove_artifacts``.

--- a/lyman/frontend.py
+++ b/lyman/frontend.py
@@ -111,6 +111,7 @@ def default_experiment_parameters():
         intensity_threshold=4.5,
         motion_threshold=1,
         spike_threshold=None,
+        wm_components=6,
         smooth_fwhm=6,
         hpf_cutoff=128,
 
@@ -118,6 +119,7 @@ def default_experiment_parameters():
         condition_names=None,
         regressor_file=None,
         regressor_names=None,
+        confound_sources=["motion"],
         hrf_model="GammaDifferenceHRF",
         temporal_deriv=False,
         confound_pca=False,

--- a/lyman/frontend.py
+++ b/lyman/frontend.py
@@ -120,6 +120,7 @@ def default_experiment_parameters():
         regressor_file=None,
         regressor_names=None,
         confound_sources=["motion"],
+        remove_artifacts=True,
         hrf_model="GammaDifferenceHRF",
         temporal_deriv=False,
         confound_pca=False,

--- a/lyman/workflows/model.py
+++ b/lyman/workflows/model.py
@@ -28,7 +28,7 @@ def create_timeseries_model_workflow(name="model", exp_info=None):
         exp_info = lyman.default_experiment_parameters()
 
     # Define constant inputs
-    inputs = ["realign_file", "artifact_file", "timeseries"]
+    inputs = ["realign_file", "nuisance_file", "artifact_file", "timeseries"]
 
     # Possibly add the design and regressor files to the inputs
     if exp_info["design_name"] is not None:
@@ -41,7 +41,8 @@ def create_timeseries_model_workflow(name="model", exp_info=None):
 
     # Set up the experimental design
     modelsetup = MapNode(ModelSetup(exp_info=exp_info),
-                         ["timeseries", "realign_file", "artifact_file"],
+                         ["timeseries", "realign_file",
+                          "nuisance_file", "artifact_file"],
                          "modelsetup")
 
     # For some nodes, make it possible to request extra memory
@@ -96,6 +97,7 @@ def create_timeseries_model_workflow(name="model", exp_info=None):
     model.connect([
         (inputnode, modelsetup,
             [("realign_file", "realign_file"),
+             ("nuisance_file", "nuisance_file"),
              ("artifact_file", "artifact_file"),
              ("timeseries", "timeseries")]),
         (inputnode, modelestimate,
@@ -161,6 +163,7 @@ class ModelSetupInput(BaseInterfaceInputSpec):
     timeseries = File(exists=True)
     design_file = File(exists=True)
     realign_file = File(exists=True)
+    nuisance_file = File(exists=True)
     artifact_file = File(exists=True)
     regressor_file = File(exists=True)
 
@@ -214,9 +217,35 @@ class ModelSetup(BaseInterface):
         else:
             design = None
 
+        # Get confound information to add to the model
+        confounds = []
+        sources = exp_info["confound_sources"]
+        bad_sources = set(sources) - set(["motion", "wm", "brain"])
+        if bad_sources:
+            msg = ("Invalid confound source specification: {}"
+                   .format(list(bad_sources)))
+            raise ValueError(msg)
+
         # Get the motion correction parameters
-        realign = pd.read_csv(self.inputs.realign_file)
-        realign = realign.filter(regex="rot|trans").apply(stats.zscore)
+        if "motion" in sources:
+            realign = pd.read_csv(self.inputs.realign_file)
+            realign = realign.filter(regex="rot|trans").apply(stats.zscore)
+            confounds.append(realign)
+
+        # Get the anatomical nuisance sources
+        nuisance = pd.read_csv(self.inputs.nuisance_file).apply(stats.zscore)
+        if "wm" in sources:
+            wm = nuisance.filter(regex="wm")
+            confounds.append(wm)
+        if "brain" in sources:
+            brain = nuisance["brain"]
+            confounds.append(brain)
+
+        # Combine the different confound sources
+        if confounds:
+            confounds = pd.concat(confounds, axis=1)
+        else:
+            confounds = None
 
         # Get the image artifacts
         artifacts = pd.read_csv(self.inputs.artifact_file).max(axis=1)
@@ -241,7 +270,7 @@ class ModelSetup(BaseInterface):
                              hrf_model=hrf,
                              ntp=ntp,
                              tr=tr,
-                             confounds=realign,
+                             confounds=confounds,
                              artifacts=artifacts,
                              regressors=regressors,
                              condition_names=exp_info["condition_names"],

--- a/lyman/workflows/model.py
+++ b/lyman/workflows/model.py
@@ -248,7 +248,10 @@ class ModelSetup(BaseInterface):
             confounds = None
 
         # Get the image artifacts
-        artifacts = pd.read_csv(self.inputs.artifact_file).max(axis=1)
+        if exp_info["remove_artifacts"]:
+            artifacts = pd.read_csv(self.inputs.artifact_file).max(axis=1)
+        else:
+            artifacts = None
 
         # Get the additional model regressors
         if isdefined(self.inputs.regressor_file):

--- a/lyman/workflows/preproc.py
+++ b/lyman/workflows/preproc.py
@@ -145,6 +145,8 @@ def create_preprocessing_workflow(name="preproc", exp_info=None):
             [("subject_id", "inputs.subject_id")]),
         (skullstrip, confounds,
             [("outputs.mask_file", "inputs.brain_mask")]),
+        (coregister, confounds,
+            [("outputs.tkreg_mat", "inputs.reg_file")]),
         (inputnode, saveparams,
             [("timeseries", "in_file")]),
         ])

--- a/lyman/workflows/preproc.py
+++ b/lyman/workflows/preproc.py
@@ -1205,7 +1205,8 @@ class ExtractConfounds(BaseInterface):
         brain_mask = nib.load(self.inputs.brain_mask).get_data()
 
         # Set up the output dataframe
-        wm_cols = ["wm{:d}".format(i) for i in range(self.inputs.n_components)]
+        wm_cols = ["wm_{:d}".format(i)
+                   for i in range(self.inputs.n_components)]
         cols = wm_cols + ["brain"]
         index = np.arange(ts_data.shape[-1])
         out_df = pd.DataFrame(index=index, columns=cols, dtype=np.float)

--- a/scripts/run_fmri.py
+++ b/scripts/run_fmri.py
@@ -114,6 +114,8 @@ def main(arglist):
     # Possibly execute the workflow, depending on the command line
     lyman.run_workflow(preproc, "preproc", args)
 
+    preproc.write_graph("what_the_fuck.dot")
+
     # ----------------------------------------------------------------------- #
     # Timeseries Model
     # ----------------------------------------------------------------------- #

--- a/scripts/run_fmri.py
+++ b/scripts/run_fmri.py
@@ -4,8 +4,12 @@ Main execution script for fMRI analysis in the Lyman ecosystem.
 
 """
 import os
+
+# Needed currently to avoid crash in model code
+# Also nipype parallelism doesn't play well with this
+os.environ["MKL_NUM_THREADS"] = "1"
+
 import sys
-import time
 import shutil
 import os.path as op
 from textwrap import dedent

--- a/scripts/run_fmri.py
+++ b/scripts/run_fmri.py
@@ -114,8 +114,6 @@ def main(arglist):
     # Possibly execute the workflow, depending on the command line
     lyman.run_workflow(preproc, "preproc", args)
 
-    preproc.write_graph("what_the_fuck.dot")
-
     # ----------------------------------------------------------------------- #
     # Timeseries Model
     # ----------------------------------------------------------------------- #

--- a/scripts/run_fmri.py
+++ b/scripts/run_fmri.py
@@ -126,6 +126,7 @@ def main(arglist):
     model_templates = dict(
         timeseries=op.join(model_base, smoothing + "_timeseries.nii.gz"),
         realign_file=op.join(model_base, "realignment_params.csv"),
+        nuisance_file=op.join(model_base, "nuisance_variables.csv"),
         artifact_file=op.join(model_base, "artifacts.csv"),
         )
 


### PR DESCRIPTION

- Added the ability to include additional nuisance variables in the model.
  This can now include eigenvariates of deep white matter timeseries and the
  mean signal from across the whole brain. This involves the new experiment
  options ``wm_components`` and ``confound_sources``.

- Made the inclusion of artifact indicator vectors in the design matrix optional.
  See the new experiment option ``remove_artifacts``
