### PR TITLE
Save func2anat registration matrix to reg directory for epi registrations

### DIFF
--- a/doc/release/v0.0.10.txt
+++ b/doc/release/v0.0.10.txt
@@ -13,4 +13,4 @@ Registration workflow
 
 - The correct registration matrix to go from the epi space to the anatomy is
   now written out during the registration so that downstream results from
-  experiments that use the ``-regspace`` flag are correct.
+  experiments that use the ``-regexp`` flag are correct.

--- a/doc/release/v0.0.10.txt
+++ b/doc/release/v0.0.10.txt
@@ -1,0 +1,16 @@
+
+v0.0.10 (Unreleased)
+--------------------
+
+Command line interface
+~~~~~~~~~~~~~~~~~~~~~~
+
+- The full command-line argument namespace is now saved out with the other
+  experiment parameters for better reproducibility.
+
+Registration workflow
+~~~~~~~~~~~~~~~~~~~~~
+
+- The correct registration matrix to go from the epi space to the anatomy is
+  now written out during the registration so that downstream results from
+  experiments that use the ``-regspace`` flag are correct.

--- a/lyman/frontend.py
+++ b/lyman/frontend.py
@@ -33,7 +33,7 @@ def gather_project_info():
     return project_dict
 
 
-def gather_experiment_info(exp_name=None, altmodel=None):
+def gather_experiment_info(exp_name=None, altmodel=None, args=None):
     """Import an experiment module and add some formatted information."""
     lyman_dir = os.environ["LYMAN_DIR"]
 
@@ -88,6 +88,10 @@ def gather_experiment_info(exp_name=None, altmodel=None):
 
     # Build contrasts list if neccesary
     exp_dict["contrast_names"] = [c[0] for c in exp_dict["contrasts"]]
+
+    # Add command line arguments for reproducibility
+    if args is not None:
+        exp_dict["command_line"] = vars(args)
 
     return exp_dict
 

--- a/lyman/tools/fileutils.py
+++ b/lyman/tools/fileutils.py
@@ -22,7 +22,7 @@ class SaveParameters(BaseInterface):
 
     input_spec = SaveParametersInput
     output_spec = SaveParametersOutput
-    overwrite = True
+    _always_run = True
 
     def _run_interface(self, runtime):
 

--- a/lyman/tools/fileutils.py
+++ b/lyman/tools/fileutils.py
@@ -22,6 +22,7 @@ class SaveParameters(BaseInterface):
 
     input_spec = SaveParametersInput
     output_spec = SaveParametersOutput
+    overwrite = True
 
     def _run_interface(self, runtime):
 

--- a/lyman/workflows/registration.py
+++ b/lyman/workflows/registration.py
@@ -15,6 +15,7 @@ For normalizations to mni space, two different warps can be used
 """
 import os
 import os.path as op
+import shutil
 import numpy as np
 
 from nipype import Workflow, Node, IdentityInterface
@@ -368,10 +369,10 @@ class EPIModelRegistration(EPIRegistration,
                 runtime = self.apply_fsl_rigid(runtime, in_file,
                                                out_file, full_rigid)
 
-            # Save out the matrix to go from this space to the anatomy
+            # Copy the matrix to go from this space to the anatomy
             if not i:
-                reg_fname = op.join(out_dir, op.basename(first_rigid))
-                out_files.append(op.realpath(reg_fname))
+                out_first_rigid = op.join(out_dir, op.basename(first_rigid))
+                shutil.copyfile(first_rigid, out_first_rigid)
 
         self.out_files = out_files
         return runtime
@@ -476,10 +477,10 @@ class EPITimeseriesRegistration(EPIRegistration,
             runtime = self.apply_fsl_rigid(runtime, run_mean,
                                            out_mean, full_rigid)
 
-            # Save out the matrix to go from this space to the anatomy
+            # Copy the matrix to go from this space to the anatomy
             if not i:
-                reg_fname = op.join(out_dir, op.basename(first_rigid))
-                out_files.append(op.realpath(reg_fname))
+                out_first_rigid = op.join(out_dir, op.basename(first_rigid))
+                shutil.copyfile(first_rigid, out_first_rigid)
 
         self.out_files = out_files
         return runtime

--- a/lyman/workflows/registration.py
+++ b/lyman/workflows/registration.py
@@ -47,6 +47,8 @@ def create_reg_workflow(name="reg", space="mni",
 
     if space == "mni":
         fields.extend(["affine", "warpfield"])
+    else:
+        fields.extend(["tkreg_rigid"])
 
     inputnode = Node(IdentityInterface(fields), "inputnode")
 
@@ -113,6 +115,7 @@ class EPIRegInput(BaseInterfaceInputSpec):
 
     rigids = InputMultiPath(File(exists=True))
     first_rigid = File(exists=True)
+    tkreg_rgiid = File(exists=True)
 
 
 class MNIModelRegInput(MNIRegInput,
@@ -371,7 +374,8 @@ class EPIModelRegistration(EPIRegistration,
 
             # Copy the matrix to go from this space to the anatomy
             if not i:
-                out_first_rigid = op.join(out_dir, op.basename(first_rigid))
+                tkreg_fname = op.basename(self.inputs.tkreg_rigid)
+                out_first_rigid = op.join(out_dir, tkreg_fname)
                 shutil.copyfile(first_rigid, out_first_rigid)
 
         self.out_files = out_files
@@ -479,7 +483,8 @@ class EPITimeseriesRegistration(EPIRegistration,
 
             # Copy the matrix to go from this space to the anatomy
             if not i:
-                out_first_rigid = op.join(out_dir, op.basename(first_rigid))
+                tkreg_fname = op.basename(self.inputs.tkreg_rigid)
+                out_first_rigid = op.join(out_dir, tkreg_fname)
                 shutil.copyfile(first_rigid, out_first_rigid)
 
         self.out_files = out_files

--- a/lyman/workflows/registration.py
+++ b/lyman/workflows/registration.py
@@ -115,7 +115,7 @@ class EPIRegInput(BaseInterfaceInputSpec):
 
     rigids = InputMultiPath(File(exists=True))
     first_rigid = File(exists=True)
-    tkreg_rgiid = File(exists=True)
+    tkreg_rigid = File(exists=True)
 
 
 class MNIModelRegInput(MNIRegInput,

--- a/lyman/workflows/registration.py
+++ b/lyman/workflows/registration.py
@@ -377,8 +377,8 @@ class EPIModelRegistration(EPIRegistration,
             # Copy the matrix to go from this space to the anatomy
             if not i:
                 tkreg_fname = op.basename(self.inputs.tkreg_rigid)
-                out_first_rigid = op.join(out_dir, tkreg_fname)
-                shutil.copyfile(self.inputs.tkreg_rigid, out_first_rigid)
+                out_tkreg = op.join(out_dir, tkreg_fname)
+                shutil.copyfile(self.inputs.tkreg_rigid, out_tkreg)
 
         self.out_files = out_files
         return runtime
@@ -486,8 +486,8 @@ class EPITimeseriesRegistration(EPIRegistration,
             # Copy the matrix to go from this space to the anatomy
             if not i:
                 tkreg_fname = op.basename(self.inputs.tkreg_rigid)
-                out_first_rigid = op.join(out_dir, tkreg_fname)
-                shutil.copyfile(self.inputs.tkreg_rigid, out_first_rigid)
+                out_tkreg = op.join(out_dir, tkreg_fname)
+                shutil.copyfile(self.inputs.tkreg_rigid, out_tkreg)
 
         self.out_files = out_files
         return runtime

--- a/lyman/workflows/registration.py
+++ b/lyman/workflows/registration.py
@@ -41,8 +41,10 @@ def create_reg_workflow(name="reg", space="mni",
         fields = ["copes", "varcopes", "sumsquares"]
     elif regtype == "timeseries":
         fields = ["timeseries"]
+
     if cross_exp:
         fields.extend(["first_rigid"])
+
     fields.extend(["means", "masks", "rigids"])
 
     if space == "mni":
@@ -376,7 +378,7 @@ class EPIModelRegistration(EPIRegistration,
             if not i:
                 tkreg_fname = op.basename(self.inputs.tkreg_rigid)
                 out_first_rigid = op.join(out_dir, tkreg_fname)
-                shutil.copyfile(first_rigid, out_first_rigid)
+                shutil.copyfile(self.inputs.tkreg_rigid, out_first_rigid)
 
         self.out_files = out_files
         return runtime
@@ -485,7 +487,7 @@ class EPITimeseriesRegistration(EPIRegistration,
             if not i:
                 tkreg_fname = op.basename(self.inputs.tkreg_rigid)
                 out_first_rigid = op.join(out_dir, tkreg_fname)
-                shutil.copyfile(first_rigid, out_first_rigid)
+                shutil.copyfile(self.inputs.tkreg_rigid, out_first_rigid)
 
         self.out_files = out_files
         return runtime

--- a/lyman/workflows/registration.py
+++ b/lyman/workflows/registration.py
@@ -368,6 +368,11 @@ class EPIModelRegistration(EPIRegistration,
                 runtime = self.apply_fsl_rigid(runtime, in_file,
                                                out_file, full_rigid)
 
+            # Save out the matrix to go from this space to the anatomy
+            if not i:
+                reg_fname = op.basename(first_rigid)
+                out_files.append(op.join(out_dir, reg_fname))
+
         self.out_files = out_files
         return runtime
 
@@ -470,6 +475,11 @@ class EPITimeseriesRegistration(EPIRegistration,
             out_mean = op.join(out_dir, out_mean_fname)
             runtime = self.apply_fsl_rigid(runtime, run_mean,
                                            out_mean, full_rigid)
+
+            # Save out the matrix to go from this space to the anatomy
+            if not i:
+                reg_fname = op.basename(first_rigid)
+                out_files.append(op.join(out_dir, reg_fname))
 
         self.out_files = out_files
         return runtime

--- a/lyman/workflows/registration.py
+++ b/lyman/workflows/registration.py
@@ -370,8 +370,8 @@ class EPIModelRegistration(EPIRegistration,
 
             # Save out the matrix to go from this space to the anatomy
             if not i:
-                reg_fname = op.basename(first_rigid)
-                out_files.append(op.join(out_dir, reg_fname))
+                reg_fname = op.join(out_dir, op.basename(first_rigid))
+                out_files.append(op.realpath(reg_fname))
 
         self.out_files = out_files
         return runtime
@@ -478,8 +478,8 @@ class EPITimeseriesRegistration(EPIRegistration,
 
             # Save out the matrix to go from this space to the anatomy
             if not i:
-                reg_fname = op.basename(first_rigid)
-                out_files.append(op.join(out_dir, reg_fname))
+                reg_fname = op.join(out_dir, op.basename(first_rigid))
+                out_files.append(op.realpath(reg_fname))
 
         self.out_files = out_files
         return runtime

--- a/lyman/workflows/surfols.py
+++ b/lyman/workflows/surfols.py
@@ -132,7 +132,7 @@ class RemoveEmpty(BaseInterface):
     def _run_interface(self, runtime):
 
         good_images = [f for f in self.inputs.in_files
-                       if not np.allclose(nib.load(f).get_data(), 0).any()]
+                       if not np.allclose(nib.load(f).get_data(), 0)]
         self.good_images = good_images
         return runtime
 

--- a/scripts/run_fmri.py
+++ b/scripts/run_fmri.py
@@ -224,6 +224,9 @@ def main(arglist):
                                              "normalization/warpfield.nii.gz")
         reg_templates["affine"] = op.join(data_dir, "{subject_id}",
                                           "normalization/affine." + aff_ext)
+    else:
+        reg_templates["tkreg_rigid"] = op.join("{subject_id}/preproc",
+                                               "run_1/func2anat_tkreg.dat")
 
     # Rigid (6dof) functional-to-anatomical matrices
     rigid_stem = "{subject_id}/preproc/run_*/func2anat_"

--- a/scripts/run_fmri.py
+++ b/scripts/run_fmri.py
@@ -226,9 +226,9 @@ def main(arglist):
                                           "normalization/affine." + aff_ext)
     else:
         if args.regexp is None:
-            tkreg_base = op.join(project["analysis_dir"], args.regexp)
-        else:
             tkreg_base = analysis_dir
+        else:
+            tkreg_base = op.join(project["analysis_dir"], args.regexp)
         reg_templates["tkreg_rigid"] = op.join(tkreg_base,
                                                "{subject_id}", "preproc",
                                                "run_1", "func2anat_tkreg.dat")

--- a/scripts/run_fmri.py
+++ b/scripts/run_fmri.py
@@ -294,7 +294,8 @@ def main(arglist):
     wf_name = space + "_ffx"
     ffx, ffx_input, ffx_output = wf.create_ffx_workflow(wf_name,
                                                         space,
-                                                        exp["contrast_names"])
+                                                        exp["contrast_names"],
+                                                        exp_info=exp)
 
     ext = "_warp.nii.gz" if space == "mni" else "_xfm.nii.gz"
     ffx_base = op.join("{subject_id}/reg", space, "{smoothing}/run_*")

--- a/scripts/run_fmri.py
+++ b/scripts/run_fmri.py
@@ -307,8 +307,9 @@ def main(arglist):
         reg = op.join(os.environ["FREESURFER_HOME"],
                       "average/mni152.register.dat")
     else:
-        bg = "{subject_id}/preproc/run_1/mean_func.nii.gz"
-        reg = "{subject_id}/preproc/run_1/func2anat_tkreg.dat"
+        reg_dir = "{subject_id}/reg/epi/{smoothing}/run_1"
+        bg = op.join(reg_dir, "mean_func_xfm.nii.gz")
+        reg = op.join(reg_dir, "func2anat_tkreg.dat")
     ffx_templates["anatomy"] = bg
     ffx_templates["reg_file"] = reg
 

--- a/scripts/run_fmri.py
+++ b/scripts/run_fmri.py
@@ -225,8 +225,8 @@ def main(arglist):
         reg_templates["affine"] = op.join(data_dir, "{subject_id}",
                                           "normalization/affine." + aff_ext)
     else:
-        reg_templates["tkreg_rigid"] = op.join("{subject_id}/preproc",
-                                               "run_1/func2anat_tkreg.dat")
+        reg_templates["tkreg_rigid"] = op.join("{subject_id}", "preproc",
+                                               "run_1", "func2anat_tkreg.dat")
 
     # Rigid (6dof) functional-to-anatomical matrices
     rigid_stem = "{subject_id}/preproc/run_*/func2anat_"

--- a/scripts/run_fmri.py
+++ b/scripts/run_fmri.py
@@ -225,7 +225,12 @@ def main(arglist):
         reg_templates["affine"] = op.join(data_dir, "{subject_id}",
                                           "normalization/affine." + aff_ext)
     else:
-        reg_templates["tkreg_rigid"] = op.join("{subject_id}", "preproc",
+        if args.regexp is None:
+            tkreg_base = op.join(project["analysis_dir"], args.regexp)
+        else:
+            tkreg_base = analysis_dir
+        reg_templates["tkreg_rigid"] = op.join(tkreg_base,
+                                               "{subject_id}", "preproc",
                                                "run_1", "func2anat_tkreg.dat")
 
     # Rigid (6dof) functional-to-anatomical matrices

--- a/scripts/run_fmri.py
+++ b/scripts/run_fmri.py
@@ -32,7 +32,7 @@ def main(arglist):
 
     # Get and process specific information
     project = lyman.gather_project_info()
-    exp = lyman.gather_experiment_info(args.experiment, args.altmodel)
+    exp = lyman.gather_experiment_info(args.experiment, args.altmodel, args)
 
     # Set up the SUBJECTS_DIR for Freesurfer
     os.environ["SUBJECTS_DIR"] = project["data_dir"]

--- a/scripts/run_group.py
+++ b/scripts/run_group.py
@@ -28,7 +28,7 @@ def main(arglist):
 
     # Get and process specific information
     project = lyman.gather_project_info()
-    exp = lyman.gather_experiment_info(args.experiment, args.altmodel)
+    exp = lyman.gather_experiment_info(args.experiment, args.altmodel, args)
 
     if args.experiment is None:
         args.experiment = project["default_exp"]

--- a/scripts/run_group.py
+++ b/scripts/run_group.py
@@ -83,8 +83,9 @@ def main(arglist):
             dofs=op.join(mfx_base, "tdof_t1.nii.gz")))
     else:
         templates.update(dict(
-            reg_file=op.join(anal_dir_base, "{subject_id}/preproc/run_1",
-                             "func2anat_tkreg.dat")))
+            reg_file=op.join(anal_dir_base,
+                             "{subject_id}/reg/epi/", ffxsmooth,
+                             "run_1/func2anat_tkreg.dat")))
 
     # Workflow source node
     mfx_source = MapNode(SelectFiles(templates,


### PR DESCRIPTION
Downstream results for a surface-based analysis when ``-regexp`` was used will now be correct.

Also adds the command line arguments to the experiment dictionary so that they are saved in the `experiment_params.json` file.