### PR TITLE
Update parallel for Jupyter notebooks in maskfactory

### DIFF
--- a/lyman/maskfactory.py
+++ b/lyman/maskfactory.py
@@ -4,8 +4,8 @@ import os.path as op
 import shutil
 from tempfile import mkdtemp
 from subprocess import check_output
-from IPython.parallel import Client
-from IPython.parallel.error import TimeoutError
+from ipyparallel import Client
+from ipyparallel.error import TimeoutError
 
 import numpy as np
 import nibabel as nib


### PR DESCRIPTION
New update to ipython moved IPython.parallel to ipyparallel: https://github.com/ipython/ipyparallel
