### PR TITLE
Split off temporal interpolation into sub workflow; add siemens interleaved

### DIFF
--- a/doc/experiments.rst
+++ b/doc/experiments.rst
@@ -77,8 +77,11 @@ Preprocessing Parameters
     A boolean that specifies whether slice-time correction should be performed.
 
    interleaved
-    A boolean that specifies whether the data were acquired with an interleaved
-    protocol. Only relevant if ``temporal_interp`` is True.
+    A string or boolean that specifies whether the data were acquired with an
+    interleaved protocol. Only relevant if ``temporal_interp`` is True. The
+    only valid string is ``"siemens"``, which indicates a Siemens interleaved
+    sequence (slice order depends on number of slices). Set to ``True`` if you
+    are using an interleaved acquisition on a GE scanner.
 
    coreg_init
     A string that is either ``"fsl"`` or ``"header"``. This controls how the

--- a/doc/release/v0.0.11.txt
+++ b/doc/release/v0.0.11.txt
@@ -2,6 +2,8 @@
 v0.0.11 (Unreleased)
 --------------------
 
+- Fixed slice time correction for data collected on a Siemens scanner. The Siemens interleaved pulse sequence changes the order of slices depending on whether there is an odd or even number of slices (for some insane reason). It is now possible to set ``interleaved="siemens"`` in your experiment file to handle this issue properly. See `this blog post <https://practicalfmri.blogspot.com/2012/07/siemens-slice-ordering.html>`_ for more information.
+
 - The ``lyman.mvpa`` module has been removed.
 
 - Added the ``view_ffx_results.py`` script, which is a wrapper around ``Freeview`` to boot up a useful visualization of fixed effects statistics on the high-resolution anatomical image and surface mesh.

--- a/lyman/workflows/preproc.py
+++ b/lyman/workflows/preproc.py
@@ -361,8 +361,8 @@ def create_slicetime_workflow(name="slicetime", TR=2,
     inputnode = Node(IdentityInterface(["timeseries"]), "inputs")
 
     slicetimer = MapNode(fsl.SliceTimer(time_repetition=TR),
-                        "in_file",
-                        "slicetime")
+                         "in_file",
+                         "slicetime")
 
     if slice_order == "down":
         slicetimer.inputs.index_dir = True

--- a/lyman/workflows/preproc.py
+++ b/lyman/workflows/preproc.py
@@ -173,7 +173,7 @@ def create_preprocessing_workflow(name="preproc", exp_info=None):
     if exp_info["temporal_interp"]:
         preproc.connect([
             (realign, slicetime,
-                [("outputs.timeseries", "intputs.timeseries")]),
+                [("outputs.timeseries", "inputs.timeseries")]),
             (slicetime, skullstrip,
                 [("outputs.timeseries", "inputs.timeseries")]),
             ])

--- a/lyman/workflows/preproc.py
+++ b/lyman/workflows/preproc.py
@@ -923,7 +923,7 @@ class SiemensSliceOrder(BaseInterface):
             # Even slice number starts with even slices
             slice_order = np.r_[slices[1::2], slices[::2]]
 
-        np.savetxt(slice_order, "slice_order.txt", fmt="%d")
+        np.savetxt("slice_order.txt", slice_order, fmt="%d")
 
     _list_outputs = list_out_file("slice_order.txt")
 

--- a/lyman/workflows/preproc.py
+++ b/lyman/workflows/preproc.py
@@ -925,6 +925,8 @@ class SiemensSliceOrder(BaseInterface):
 
         np.savetxt("slice_order.txt", slice_order, fmt="%d")
 
+        return runtime
+
     _list_outputs = list_out_file("slice_order.txt")
 
 


### PR DESCRIPTION
Siemens slice order when the acquisition is interleaved depends on the
number of slices. This change uses the custom slice order option to handle
that weirdness (but does not otherwise expose custom slice order/timing,
so it probably still won't work for SMS sequences).

See this blog post for more information:
https://practicalfmri.blogspot.com/2012/07/siemens-slice-ordering.html
