### PR TITLE
Rework lyman frontend functions and information specification

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -50,6 +50,7 @@ def lyman_info(tmpdir):
 
     exp_info = Bunch(
         name="exp_alpha",
+        crop_frames=2,
         tr=1.5,
     )
 

--- a/conftest.py
+++ b/conftest.py
@@ -6,8 +6,6 @@ import pytest
 
 from lyman.frontend import LymanInfo
 
-from moss import Bunch  # TODO change to lyman version when implemented
-
 
 @pytest.fixture()
 def execdir(tmpdir):

--- a/conftest.py
+++ b/conftest.py
@@ -4,6 +4,8 @@ import nibabel as nib
 
 import pytest
 
+from lyman.frontend import LymanInfo
+
 from moss import Bunch  # TODO change to lyman version when implemented
 
 
@@ -37,7 +39,13 @@ def lyman_info(tmpdir):
         },
     }
 
-    proj_info = Bunch(
+    contrasts = [
+        ("a", ["a", "b"], [1, 0]),
+        ("b", ["b"], [1]),
+        ("a-b", ["a", "b"], [1, -1])
+    ]
+
+    info = LymanInfo().trait_set(
         data_dir=str(data_dir),
         proc_dir=str(proc_dir),
         cache_dir=str(cache_dir),
@@ -46,23 +54,16 @@ def lyman_info(tmpdir):
         fm_template="{session}_{encoding}.nii.gz",
         ts_template="{session}_{experiment}_{run}.nii.gz",
         sb_template="{session}_{experiment}_{run}_sbref.nii.gz",
-    )
-
-    exp_info = Bunch(
-        name="exp_alpha",
+        experiment_name="exp_alpha",
         crop_frames=2,
         tr=1.5,
-    )
-
-    model_info = Bunch(
-        name="model_a",
+        model_name="model_a",
         smooth_fwhm=4,
         surface_smoothing=True,
         hpf_cutoff=10,
         save_residuals=True,
-
         # TODO FIX
-        contrasts=["a", "b", "a-b"]
+        contrasts=contrasts,
     )
 
     subjects = ["subj01", "subj02"]
@@ -89,11 +90,9 @@ def lyman_info(tmpdir):
     n_params = len(design["condition"].unique())
 
     return dict(
-        proj_info=proj_info,
+        info=info,
         subjects=subjects,
         sessions=sessions,
-        exp_info=exp_info,
-        model_info=model_info,
         proc_dir=proc_dir,
         data_dir=data_dir,
 
@@ -203,8 +202,8 @@ def timeseries(template):
     session = "sess01"
     run = "run01"
 
-    exp_name = template["exp_info"].name
-    model_name = template["model_info"].name
+    exp_name = template["info"].experiment_name
+    model_name = template["info"].model_name
 
     vol_shape = template["vol_shape"]
     n_tp = template["n_tp"]

--- a/lyman/frontend.py
+++ b/lyman/frontend.py
@@ -239,7 +239,7 @@ def info(experiment=None, model=None, lyman_dir=None):
     return info
 
 
-def subjects(subject_arg=None):
+def subjects(subject_arg=None, session_arg=None, lyman_dir=None):
     """Intelligently find a list of subjects in a variety of ways."""
     # TODO do we need a duplicate sessions text file or just get from scans
     if subject_arg is None:

--- a/lyman/frontend.py
+++ b/lyman/frontend.py
@@ -261,7 +261,6 @@ def determine_subjects(subject_arg=None):
 
 def execute(wf, args, info):
     """Execute a workflow from command line arguments."""
-
     crash_dir = op.join(info.cache_dir, "crashdumps")
     wf.config["execution"]["crashdump_dir"] = crash_dir
 
@@ -278,13 +277,17 @@ def execute(wf, args, info):
             fname = args.stage
         else:
             fname = args.graph
-        wf.write_graph(fname, "orig", "svg")
+        res = wf.write_graph(fname, "orig", "svg")
 
     else:
         if args.execute:
             plugin = "MultiProc"
             plugin_args = dict(n_procs=args.n_procs)
-            wf.run(plugin, plugin_args)
+            res = wf.run(plugin, plugin_args)
+        else:
+            res = None
 
-    if not args.debug:
+    if info.remove_cache and not args.debug:
         shutil.rmtree(cache_dir)
+
+    return res

--- a/lyman/frontend.py
+++ b/lyman/frontend.py
@@ -194,6 +194,7 @@ def check_extra_vars(module_vars, spec):
 
 def lyman_info(experiment=None, model=None, lyman_dir=None):
     """Load information from various modules."""
+    # TODO best name for this?
     if lyman_dir is None:
         lyman_dir = os.environ["LYMAN_DIR"]
 
@@ -231,6 +232,7 @@ def lyman_info(experiment=None, model=None, lyman_dir=None):
 
 def determine_subjects(subject_arg=None):
     """Intelligently find a list of subjects in a variety of ways."""
+    # TODO best name for this?
     if subject_arg is None:
         subject_file = op.join(os.environ["LYMAN_DIR"], "subjects.txt")
         subjects = np.loadtxt(subject_file, str).tolist()

--- a/lyman/frontend.py
+++ b/lyman/frontend.py
@@ -285,10 +285,10 @@ def subjects(subject_arg=None, sessions=None, lyman_dir=None):
         This argument can take several forms:
            - None, in which case all subject ids in scans.yaml are used.
            - A list of subject ids or single subject id which will be used.
+           - The name (without extension) of a text file in the <lyman_dir>
+             containing list of subject ids, or a list with a single entry
+             corresponding to the name of a file.
            - A single subject id, which will be used.
-           - A path to a text file with subject ids, or the name (without
-             extension) of a text file in the <lyman_dir>, or a list with a
-             single entry corresponding to one of the above two options.
     sessions : list
         A list of session ids. Only valid when there is a single subject
         in the returned list. This parameter can be used to validate that
@@ -321,8 +321,6 @@ def subjects(subject_arg=None, sessions=None, lyman_dir=None):
         subject_path = op.join(lyman_dir, subject_arg + ".txt")
         if op.isfile(subject_path):
             subjects = np.loadtxt(subject_path, str, ndmin=1).tolist()
-        elif op.isfile(subject_arg):
-            subjects = np.loadtxt(subject_arg, str, ndmin=1).tolist()
         else:
             subjects = [subject_arg]
     else:

--- a/lyman/frontend.py
+++ b/lyman/frontend.py
@@ -192,9 +192,8 @@ def check_extra_vars(module_vars, spec):
         raise RuntimeError(msg)
 
 
-def lyman_info(experiment=None, model=None, lyman_dir=None):
+def info(experiment=None, model=None, lyman_dir=None):
     """Load information from various modules."""
-    # TODO best name for this?
     if lyman_dir is None:
         lyman_dir = os.environ["LYMAN_DIR"]
 
@@ -240,9 +239,8 @@ def lyman_info(experiment=None, model=None, lyman_dir=None):
     return info
 
 
-def determine_subjects(subject_arg=None):
+def subjects(subject_arg=None):
     """Intelligently find a list of subjects in a variety of ways."""
-    # TODO best name for this, and should it handle sessions too?
     # TODO do we need a duplicate sessions text file or just get from scans
     if subject_arg is None:
         subject_file = op.join(os.environ["LYMAN_DIR"], "subjects.txt")

--- a/lyman/frontend.py
+++ b/lyman/frontend.py
@@ -191,7 +191,7 @@ def load_info_from_module(module_name, lyman_dir):
 def check_extra_vars(module_vars, spec):
     """Raise when unexpected information is defined to avoid errors."""
     kind = spec.__name__.lower().strip("info")
-    extra_vars = set(module_vars) - set(spec.trait_names())
+    extra_vars = set(module_vars) - set(spec().trait_names())
     if extra_vars:
         msg = ("The following variables were unexpectedly present in the "
                "{} information module: {}".format(kind, extra_vars))
@@ -207,6 +207,11 @@ def lyman_info(experiment=None, model=None, lyman_dir=None):
     # Load project-level information
     project_info = load_info_from_module("project", lyman_dir)
     check_extra_vars(project_info, ProjectInfo)
+
+    # Ensure that directories are specifed as real absolute paths
+    for directory in ["data", "proc", "cache"]:
+        key = directory + "_dir"
+        project_info[key] = op.abspath(op.join(lyman_dir, project_info[key]))
 
     # Load scan information
     # TODO load from yaml file
@@ -229,9 +234,9 @@ def lyman_info(experiment=None, model=None, lyman_dir=None):
 
     # Set the output traits in descending order of granularity
     info = (LymanInfo()
-            .trait_set(project_info)
-            .trait_set(experiment_info)
-            .trait_set(model_info))
+            .trait_set(**project_info)
+            .trait_set(**experiment_info)
+            .trait_set(**model_info))
 
     return info
 

--- a/lyman/frontend.py
+++ b/lyman/frontend.py
@@ -214,7 +214,9 @@ def lyman_info(experiment=None, model=None, lyman_dir=None):
         project_info[key] = op.abspath(op.join(lyman_dir, project_info[key]))
 
     # Load scan information
-    # TODO load from yaml file
+    scan_fname = op.join(lyman_dir, "scans.yaml")
+    with open(scan_fname) as fid:
+        project_info["scan_info"] = yaml.load(fid)
 
     # Load the experiment-level information
     if experiment is None:

--- a/lyman/frontend.py
+++ b/lyman/frontend.py
@@ -72,6 +72,12 @@ class ProjectInfo(HasTraits):
         run of time series data.
         """),
     )
+    voxel_size = Tuple(
+        Float(2), Float(2), Float(2),
+        desc=dedent("""
+        The voxel size to use for the functional template.
+        """),
+    )
     phase_encoding = Enum(
         "pa", "ap",
         desc=dedent("""

--- a/lyman/signals.py
+++ b/lyman/signals.py
@@ -329,8 +329,7 @@ def smoothing_matrix(measure, vertids, fwhm, exclude=None, minpool=6):
             pool = len(distmap)
             factor += 1
             if factor > 10:
-                # TODO probably better not to fail but to return data with nans
-                # (or at least make that an  option) and handle downstream
+                # Error out to avoid an infinite loop
                 raise RuntimeError("Could not find enough neighbors in mesh")
 
         # Find weights for nearby voxels

--- a/lyman/tests/test_frontend.py
+++ b/lyman/tests/test_frontend.py
@@ -58,7 +58,9 @@ class TestFrontend(object):
         with open(lyman_dir.join("exp_alpha-model_b.py"), "w") as fid:
             fid.write(model_bad)
 
-        return lyman_dir
+        yield lyman_dir
+
+        lyman_dir.remove()
 
     def test_info(self, lyman_dir, execdir):
 
@@ -91,6 +93,8 @@ class TestFrontend(object):
 
         info = frontend.info(lyman_dir=str(lyman_dir_new))
         assert info.voxel_size == (2.5, 2.5, 2.5)
+
+        lyman_dir_new.move(execdir.join("lyman"))
 
     def test_execute(self, lyman_dir, execdir):
 

--- a/lyman/tests/test_frontend.py
+++ b/lyman/tests/test_frontend.py
@@ -1,3 +1,116 @@
+import os
+from textwrap import dedent
+
+import pytest
+
+from traits.api import TraitError
 
 from .. import frontend
 
+
+class TestFrontend(object):
+
+    def test_load_info_from_module(self, execdir):
+
+        lyman_dir = execdir.mkdir("lyman")
+
+        # Write a Python module to test import from disk
+        module_text = dedent("""
+        foo = "a"
+        bar = 3
+        buz = [1, 2, 3]
+        """)
+        module_fname = lyman_dir.join("test.py")
+        with open(module_fname, "w") as fid:
+            fid.write(module_text)
+
+        expected = dict(foo="a", bar=3, buz=[1, 2, 3])
+
+        module_vars = frontend.load_info_from_module("test", lyman_dir)
+        assert module_vars == expected
+
+        # Remove the file to test import from memory
+        os.remove(module_fname)
+        module_vars = frontend.load_info_from_module("test", lyman_dir)
+        assert module_vars == expected
+
+    def test_check_extra_vars(self):
+
+        with pytest.raises(RuntimeError):
+            module_vars = {"not_a_valid_trait": True}
+            frontend.check_extra_vars(module_vars, frontend.ProjectInfo)
+
+    @pytest.fixture
+    def lyman_dir(self, execdir):
+
+        lyman_dir = execdir.mkdir("lyman")
+
+        scans = dedent("""
+        subj01:
+          sess01:
+            exp_alpha: [run01, run02]
+          ess01:
+            exp_alpha: [run01]
+            exp_beta: [run01, run01]
+        """)
+
+        project = dedent("""
+        data_dir = "../datums"
+        voxel_size = (2.5, 2.5, 2.5)
+        """)
+
+        experiment = dedent("""
+        tr = .72
+        """)
+
+        model = dedent("""
+        tr = 1.5
+        contrasts = [("a-b", ["a", "b"], [1, -1])]
+        """)
+
+        model_bad = dedent("""
+        contrasts = ["a-b", "b-a"]
+        """)
+
+        with open(lyman_dir.join("scans.yaml"), "w") as fid:
+            fid.write(scans)
+
+        with open(lyman_dir.join("project.py"), "w") as fid:
+            fid.write(project)
+
+        with open(lyman_dir.join("exp_alpha.py"), "w") as fid:
+            fid.write(experiment)
+
+        with open(lyman_dir.join("exp_alpha-model_a.py"), "w") as fid:
+            fid.write(model)
+
+        with open(lyman_dir.join("exp_alpha-model_b.py"), "w") as fid:
+            fid.write(model_bad)
+
+        return lyman_dir
+
+    def test_lyman_info(self, lyman_dir, execdir):
+
+        os.environ["LYMAN_DIR"] = str(lyman_dir)
+
+        info = frontend.lyman_info()
+        assert info.data_dir == execdir.join("datums")
+
+        model_traits = frontend.ModelInfo().trait_get()
+        assert info.trait_get(*model_traits.keys()) == model_traits
+
+        info = frontend.lyman_info("exp_alpha")
+        assert info.tr == .72
+
+        info = frontend.lyman_info("exp_alpha", "model_a")
+        assert info.tr == 1.5
+        assert info.contrasts == [("a-b", ["a", "b"], [1, -1])]
+
+        with pytest.raises(TraitError):
+            frontend.lyman_info("exp_alpha", "model_b")
+
+        lyman_dir_new = execdir.join("lyman2")
+        lyman_dir.move(lyman_dir_new)
+
+        info = frontend.lyman_info(lyman_dir=str(lyman_dir_new))
+        assert info.voxel_size == (2.5, 2.5, 2.5)

--- a/lyman/tests/test_frontend.py
+++ b/lyman/tests/test_frontend.py
@@ -60,11 +60,11 @@ class TestFrontend(object):
 
         return lyman_dir
 
-    def test_lyman_info(self, lyman_dir, execdir):
+    def test_info(self, lyman_dir, execdir):
 
         os.environ["LYMAN_DIR"] = str(lyman_dir)
 
-        info = frontend.lyman_info()
+        info = frontend.info()
         assert info.data_dir == execdir.join("datums")
         assert info.scan_info == {
             "subj01": {"sess01": {"exp_alpha": ["run01", "run02"]},
@@ -76,25 +76,25 @@ class TestFrontend(object):
         model_traits = frontend.ModelInfo().trait_get()
         assert info.trait_get(*model_traits.keys()) == model_traits
 
-        info = frontend.lyman_info("exp_alpha")
+        info = frontend.info("exp_alpha")
         assert info.tr == .72
 
-        info = frontend.lyman_info("exp_alpha", "model_a")
+        info = frontend.info("exp_alpha", "model_a")
         assert info.tr == 1.5
         assert info.contrasts == [("a-b", ["a", "b"], [1, -1])]
 
         with pytest.raises(TraitError):
-            frontend.lyman_info("exp_alpha", "model_b")
+            frontend.info("exp_alpha", "model_b")
 
         lyman_dir_new = execdir.join("lyman2")
         lyman_dir.move(lyman_dir_new)
 
-        info = frontend.lyman_info(lyman_dir=str(lyman_dir_new))
+        info = frontend.info(lyman_dir=str(lyman_dir_new))
         assert info.voxel_size == (2.5, 2.5, 2.5)
 
     def test_execute(self, lyman_dir, execdir):
 
-        info = frontend.lyman_info(lyman_dir=lyman_dir)
+        info = frontend.info(lyman_dir=lyman_dir)
 
         def f(x):
             return x ** 2

--- a/lyman/tests/test_frontend.py
+++ b/lyman/tests/test_frontend.py
@@ -112,17 +112,14 @@ class TestFrontend(object):
         subjects = frontend.subjects(["subj01", "subj02"])
         assert subjects == ["subj01", "subj02"]
 
-        subj_file = lyman_dir.join("subjects.txt")
+        subj_file = lyman_dir.join("group_one.txt")
         with open(subj_file, "w") as fid:
             fid.write("subj01")
 
-        subjects = frontend.subjects("subjects")
+        subjects = frontend.subjects("group_one")
         assert subjects == ["subj01"]
 
-        subjects = frontend.subjects(["subjects"])
-        assert subjects == ["subj01"]
-
-        subjects = frontend.subjects(str(subj_file))
+        subjects = frontend.subjects(["group_one"])
         assert subjects == ["subj01"]
 
         with pytest.raises(RuntimeError):

--- a/lyman/tests/test_frontend.py
+++ b/lyman/tests/test_frontend.py
@@ -87,6 +87,9 @@ class TestFrontend(object):
         with pytest.raises(TraitError):
             frontend.info("exp_alpha", "model_b")
 
+        with pytest.raises(RuntimeError):
+            frontend.info(model="model_b")
+
         lyman_dir_new = execdir.join("lyman2")
         lyman_dir.move(lyman_dir_new)
 
@@ -114,6 +117,9 @@ class TestFrontend(object):
             fid.write("subj01")
 
         subjects = frontend.subjects("subjects")
+        assert subjects == ["subj01"]
+
+        subjects = frontend.subjects(["subjects"])
         assert subjects == ["subj01"]
 
         subjects = frontend.subjects(str(subj_file))
@@ -168,6 +174,7 @@ class TestFrontend(object):
         res = frontend.execute(wf, args, info)
         assert res is None
 
+        args.execute = True
         fname = execdir.join("graph").join("workflow.dot")
         args.graph = fname
         res = frontend.execute(wf, args, info)

--- a/lyman/tests/test_frontend.py
+++ b/lyman/tests/test_frontend.py
@@ -1,23 +1,3 @@
-from argparse import Namespace
 
 from .. import frontend
 
-
-def test_determine_engine():
-
-    plugin_dict = dict(linear="Linear",
-                       multiproc="MultiProc",
-                       ipython="IPython",
-                       torque="PBS")
-
-    for arg, plugin_str in plugin_dict.items():
-        args = Namespace(plugin=arg, queue=None)
-        if arg == "multiproc":
-            args.nprocs = 4
-        plugin, plugin_args = frontend.determine_engine(args)
-        assert plugin == plugin_str
-
-        if arg == "multiproc":
-            assert plugin_args == dict(n_procs=4)
-        elif arg == "PBS":
-            assert plugin_args == dict(n_procs=4, qsub_args="")

--- a/lyman/tests/test_signals.py
+++ b/lyman/tests/test_signals.py
@@ -232,6 +232,13 @@ class TestSignals(object):
         with pytest.raises(ValueError):
             signals.smoothing_matrix(sm, vertids, 0)
 
+        # Test avoidance of infinite loop
+        verts = meshdata["verts"].copy()
+        verts[0] += 100
+        sm = surface.SurfaceMeasure(verts, meshdata["faces"])
+        with pytest.raises(RuntimeError):
+            signals.smoothing_matrix(sm, vertids, 1)
+
     def test_smooth_surface(self, random, meshdata):
 
         shape = 4, 3, 2

--- a/lyman/workflows/model.py
+++ b/lyman/workflows/model.py
@@ -463,6 +463,7 @@ class ModelFit(LymanInterface):
         signals.smooth_volume(ts_img, fwhm, mask_img, noise_img, inplace=True)
 
         if model_info.surface_smoothing:
+            # TODO this is double smoothing the surface voxels!
             vert_data = nib.load(self.inputs.surf_file).get_data()
             for i, mesh_file in enumerate(self.inputs.mesh_files):
                 sm = surface.SurfaceMeasure.from_file(mesh_file)

--- a/lyman/workflows/model.py
+++ b/lyman/workflows/model.py
@@ -7,9 +7,8 @@ import pandas as pd
 import nibabel as nib
 
 from nipype import Workflow, Node, JoinNode, IdentityInterface, DataSink
-from nipype.interfaces.base import traits, TraitedSpec
+from nipype.interfaces.base import traits, TraitedSpec, Bunch
 
-from moss import Bunch  # move into lyman
 from moss import glm as mossglm  # TODO move into lyman
 
 from .. import glm, signals, surface

--- a/lyman/workflows/model.py
+++ b/lyman/workflows/model.py
@@ -17,8 +17,7 @@ from ..utils import LymanInterface, image_to_matrix, matrix_to_image
 from ..visualizations import Mosaic, CarpetPlot
 
 
-def define_model_fit_workflow(proj_info, exp_info, model_info,
-                              subjects, sessions, qc=True):
+def define_model_fit_workflow(info, subjects, sessions, qc=True):
 
     # --- Workflow parameterization and data input
 
@@ -26,9 +25,9 @@ def define_model_fit_workflow(proj_info, exp_info, model_info,
     # one "flat" run-level iterable (i.e. all runs collapsing over
     # sessions). But we want to be able to specify sessions to process.
 
-    scan_info = proj_info.scan_info
-    experiment = exp_info.name
-    model = model_info.name
+    scan_info = info.scan_info
+    experiment = info.experiment_name
+    model = info.model_name
 
     iterables = generate_iterables(scan_info, experiment, subjects, sessions)
     subject_iterables, run_iterables = iterables
@@ -44,26 +43,25 @@ def define_model_fit_workflow(proj_info, exp_info, model_info,
 
     data_input = Node(ModelFitInput(experiment=experiment,
                                     model=model,
-                                    data_dir=proj_info.data_dir,
-                                    proc_dir=proj_info.proc_dir),
+                                    data_dir=info.data_dir,
+                                    proc_dir=info.proc_dir),
                       "data_input")
 
     # --- Data filtering and model fitting
 
-    fit_model = Node(ModelFit(data_dir=proj_info.data_dir,
-                              exp_info=exp_info,
-                              model_info=model_info),
+    fit_model = Node(ModelFit(data_dir=info.data_dir,
+                              info=info.trait_get()),
                      "fit_model")
 
     # --- Data output
 
-    data_output = Node(DataSink(base_directory=proj_info.proc_dir,
+    data_output = Node(DataSink(base_directory=info.proc_dir,
                                 parameterization=False),
                        "data_output")
 
     # === Assemble pipeline
 
-    cache_base = op.join(proj_info.cache_dir, exp_info.name)
+    cache_base = op.join(info.cache_dir, experiment)
     workflow = Workflow(name="model_fit", base_dir=cache_base)
 
     # Connect processing nodes
@@ -116,8 +114,7 @@ def define_model_fit_workflow(proj_info, exp_info, model_info,
     return workflow
 
 
-def define_model_results_workflow(proj_info, exp_info, model_info,
-                                  subjects, qc=True):
+def define_model_results_workflow(info, subjects, qc=True):
 
     # TODO I am copying a lot from above ...
 
@@ -128,9 +125,9 @@ def define_model_results_workflow(proj_info, exp_info, model_info,
     # sessions). Unlike in the model fit workflow, we always want to process
     # all sessions.
 
-    scan_info = proj_info.scan_info
-    experiment = exp_info.name
-    model = model_info.name
+    scan_info = info.scan_info
+    experiment = info.experiment_name
+    model = info.model_name
 
     iterables = generate_iterables(scan_info, experiment, subjects)
     subject_iterables, run_iterables = iterables
@@ -146,17 +143,17 @@ def define_model_results_workflow(proj_info, exp_info, model_info,
 
     data_input = Node(ModelResultsInput(experiment=experiment,
                                         model=model,
-                                        proc_dir=proj_info.proc_dir),
+                                        proc_dir=info.proc_dir),
                       "data_input")
 
     # --- Run-level contrast estimation
 
-    estimate_contrasts = Node(EstimateContrasts(model_info=model_info),
+    estimate_contrasts = Node(EstimateContrasts(info=info.trait_get()),
                               "estimate_contrasts")
 
     # --- Subject-level contrast estimation
 
-    model_results = JoinNode(ModelResults(model_info=model_info),
+    model_results = JoinNode(ModelResults(info=info.trait_get()),
                              name="model_results",
                              joinsource="run_source",
                              joinfield=["contrast_files",
@@ -164,22 +161,22 @@ def define_model_results_workflow(proj_info, exp_info, model_info,
 
     # --- Data output
 
-    run_output = Node(DataSink(base_directory=proj_info.proc_dir,
+    run_output = Node(DataSink(base_directory=info.proc_dir,
                                parameterization=False),
                       "run_output")
 
-    results_path = Node(ModelResultsPath(proc_dir=proj_info.proc_dir,
+    results_path = Node(ModelResultsPath(proc_dir=info.proc_dir,
                                          experiment=experiment,
                                          model=model),
                         "results_path")
 
-    subject_output = Node(DataSink(base_directory=proj_info.proc_dir,
+    subject_output = Node(DataSink(base_directory=info.proc_dir,
                                    parameterization=False),
                           "subject_output")
 
     # === Assemble pipeline
 
-    cache_base = op.join(proj_info.cache_dir, exp_info.name)
+    cache_base = op.join(info.cache_dir, experiment)
     workflow = Workflow(name="model_results", base_dir=cache_base)
 
     # Connect processing nodes
@@ -410,8 +407,7 @@ class ModelFit(LymanInterface):
         session = traits.Str()
         run = traits.Str()
         data_dir = traits.Directory(exists=True)
-        exp_info = traits.Dict()
-        model_info = traits.Dict()
+        info = traits.Dict()
         seg_file = traits.File(exists=True)
         surf_file = traits.File(exists=True)
         ts_file = traits.File(exists=True)
@@ -437,8 +433,7 @@ class ModelFit(LymanInterface):
         subject = self.inputs.subject
         session = self.inputs.session
         run = self.inputs.run
-        exp_info = Bunch(self.inputs.exp_info)
-        model_info = Bunch(self.inputs.model_info)
+        info = Bunch(self.inputs.info)
         data_dir = self.inputs.data_dir
 
         # Load the timeseries
@@ -458,11 +453,11 @@ class ModelFit(LymanInterface):
         noise_img = nib.load(self.inputs.noise_file)
 
         # Spatially filter the data
-        fwhm = model_info.smooth_fwhm
+        fwhm = info.smooth_fwhm
         # TODO use smooth_segmentation instead?
         signals.smooth_volume(ts_img, fwhm, mask_img, noise_img, inplace=True)
 
-        if model_info.surface_smoothing:
+        if info.surface_smoothing:
             # TODO this is double smoothing the surface voxels!
             vert_data = nib.load(self.inputs.surf_file).get_data()
             for i, mesh_file in enumerate(self.inputs.mesh_files):
@@ -480,8 +475,8 @@ class ModelFit(LymanInterface):
         # Temporally filter the data
         n_tp = ts_img.shape[-1]
         hpf_matrix = glm.highpass_filter_matrix(n_tp,
-                                                model_info.hpf_cutoff,
-                                                exp_info.tr)
+                                                info.hpf_cutoff,
+                                                info.tr)
         data[mask] = np.dot(hpf_matrix, data[mask].T).T
 
         # TODO remove the mean from the data
@@ -501,13 +496,13 @@ class ModelFit(LymanInterface):
         # Build the design matrix
         # TODO move out of moss and simplify
         design_file = op.join(data_dir, subject, "design",
-                              model_info.name + ".csv")
+                              info.model_name + ".csv")
         design = pd.read_csv(design_file)
         run_rows = (design.session == session) & (design.run == run)
         design = design.loc[run_rows]
         # TODO better error when this fails (maybe check earlier too)
         assert len(design) > 0
-        dmat = mossglm.DesignMatrix(design, ntp=n_tp, tr=exp_info.tr)
+        dmat = mossglm.DesignMatrix(design, ntp=n_tp, tr=info.tr)
         X = dmat.design_matrix.values
 
         # Save out the design matrix
@@ -535,7 +530,7 @@ class ModelFit(LymanInterface):
         self.write_image("beta_file", "beta.nii.gz", beta_img)
         self.write_image("error_file", "error.nii.gz", error_img)
         self.write_image("ols_file", "ols.nii.gz", ols_img)
-        if model_info.save_residuals:
+        if info.save_residuals:
             self.write_image("resid_file", "resid.nii.gz", resid_img)
 
         # Make some QC plots
@@ -568,8 +563,7 @@ class ModelFit(LymanInterface):
 class EstimateContrasts(LymanInterface):
 
     class input_spec(TraitedSpec):
-        exp_info = traits.Dict()
-        model_info = traits.Dict()
+        info = traits.Dict()
         mask_file = traits.File(exists=True)
         beta_file = traits.File(exists=True)
         ols_file = traits.File(exists=True)
@@ -600,7 +594,7 @@ class EstimateContrasts(LymanInterface):
         XtXinv = XtXinv.reshape(n_ev, n_ev, n_vox).T
 
         # Obtain list of contrast matrices
-        # C = model_info.contrasts
+        # C = info.contrasts
         # TODO how are we going to do this? Hardcode for now.
         # TODO do we want to enforce vectors or do we ever want F stats
         C = [np.array([1, 0, 0, 0]),
@@ -630,7 +624,7 @@ class EstimateContrasts(LymanInterface):
 class ModelResults(LymanInterface):
 
     class input_spec(TraitedSpec):
-        model_info = traits.Dict()
+        info = traits.Dict()
         anat_file = traits.File(exists=True)
         contrast_files = traits.List(traits.File(exists=True))
         variance_files = traits.List(traits.File(exists=True))
@@ -640,7 +634,7 @@ class ModelResults(LymanInterface):
 
     def _run_interface(self, runtime):
 
-        model_info = Bunch(self.inputs.model_info)
+        info = Bunch(self.inputs.info)
 
         # Load the anatomical template to get image geometry information
         anat_img = nib.load(self.inputs.anat_file)
@@ -648,10 +642,12 @@ class ModelResults(LymanInterface):
 
         # TODO define contrasts properly accounting for missing EVs
         result_directories = []
-        for i, contrast in enumerate(model_info.contrasts):
+        for i, contrast_tuple in enumerate(info.contrasts):
 
-            result_directories.append(op.abspath(contrast))
-            os.makedirs(op.join(contrast, "qc"))
+            name, _, _ = contrast_tuple
+
+            result_directories.append(op.abspath(name))
+            os.makedirs(op.join(name, "qc"))
 
             con_frames = []
             var_frames = []
@@ -686,20 +682,20 @@ class ModelResults(LymanInterface):
             t_img = matrix_to_image(t_ffx.T, mask_img)
 
             # Write out output images
-            con_img.to_filename(op.join(contrast, "contrast.nii.gz"))
-            var_img.to_filename(op.join(contrast, "variance.nii.gz"))
-            t_img.to_filename(op.join(contrast, "tstat.nii.gz"))
-            mask_img.to_filename(op.join(contrast, "mask.nii.gz"))
+            con_img.to_filename(op.join(name, "contrast.nii.gz"))
+            var_img.to_filename(op.join(name, "variance.nii.gz"))
+            t_img.to_filename(op.join(name, "tstat.nii.gz"))
+            mask_img.to_filename(op.join(name, "mask.nii.gz"))
 
             # Contrast t statistic overlay
             stat_m = Mosaic(anat_img, t_img, mask_img, show_mask=True)
             stat_m.plot_overlay("coolwarm", -10, 10)
-            stat_m.savefig(op.join(contrast, "qc", "tstat.png"), close=True)
+            stat_m.savefig(op.join(name, "qc", "tstat.png"), close=True)
 
             # Analysis mask
             mask_m = Mosaic(anat_img, mask_img)
             mask_m.plot_mask()
-            mask_m.savefig(op.join(contrast, "qc", "mask.png"), close=True)
+            mask_m.savefig(op.join(name, "qc", "mask.png"), close=True)
 
         # Output a list of directories with results.
         # This makes the connections in the workflow more opaque, but it

--- a/lyman/workflows/preproc.py
+++ b/lyman/workflows/preproc.py
@@ -57,7 +57,8 @@ def define_preproc_workflow(proj_info, exp_info, subjects, sessions, qc=True):
                               data_dir=proj_info.data_dir,
                               proc_dir=proj_info.proc_dir,
                               sb_template=proj_info.sb_template,
-                              ts_template=proj_info.ts_template),
+                              ts_template=proj_info.ts_template,
+                              crop_frames=exp_info.crop_frames),
                      name="run_input")
 
     # --- Warpfield estimation using topup
@@ -579,8 +580,6 @@ class RunInput(LymanInterface, TimeSeriesGIF):
         experiment = traits.Str()
         sb_template = traits.Str()
         ts_template = traits.Str()
-
-        # TODO this default should be defined at the project/experiment level
         crop_frames = traits.Int(0, usedefault=True)
 
     class output_spec(TraitedSpec):

--- a/lyman/workflows/template.py
+++ b/lyman/workflows/template.py
@@ -13,7 +13,7 @@ from ..utils import LymanInterface
 from ..visualizations import Mosaic
 
 
-def define_template_workflow(proj_info, subjects, qc=True):
+def define_template_workflow(info, subjects, qc=True):
 
     # --- Workflow parameterization
 
@@ -22,7 +22,7 @@ def define_template_workflow(proj_info, subjects, qc=True):
                           iterables=("subject", subjects))
 
     # Data input
-    template_input = Node(TemplateInput(data_dir=proj_info.data_dir),
+    template_input = Node(TemplateInput(data_dir=info.data_dir),
                           "template_input")
 
     # --- Definition of functional template space
@@ -79,13 +79,13 @@ def define_template_workflow(proj_info, subjects, qc=True):
 
     # --- Workflow ouptut
 
-    template_output = Node(DataSink(base_directory=proj_info.proc_dir,
+    template_output = Node(DataSink(base_directory=info.proc_dir,
                                     parameterization=False),
                            "template_output")
 
     # === Assemble pipeline
 
-    workflow = Workflow(name="template", base_dir=proj_info.cache_dir)
+    workflow = Workflow(name="template", base_dir=info.cache_dir)
 
     processing_edges = [
 

--- a/lyman/workflows/template.py
+++ b/lyman/workflows/template.py
@@ -31,7 +31,7 @@ def define_template_workflow(info, subjects, qc=True):
 
     zoom_image = Node(fs.MRIConvert(resample_type="cubic",
                                     out_type="niigz",
-                                    vox_size=(2, 2, 2),  # TODO make proj param
+                                    vox_size=info.voxel_size,
                                     ),
                       "zoom_image")
 

--- a/lyman/workflows/tests/test_preproc.py
+++ b/lyman/workflows/tests/test_preproc.py
@@ -22,25 +22,22 @@ class TestPreprocWorkflow(object):
 
     def test_preproc_workflow_creation(self, lyman_info):
 
-        proj_info = lyman_info["proj_info"]
+        info = lyman_info["info"]
         subjects = lyman_info["subjects"]
         sessions = lyman_info["sessions"]
-        exp_info = lyman_info["exp_info"]
 
-        wf = preproc.define_preproc_workflow(
-            proj_info, exp_info, subjects, sessions,
-        )
+        wf = preproc.define_preproc_workflow(info, subjects, sessions)
 
         # Check basic information about the workflow
         assert isinstance(wf, nipype.Workflow)
         assert wf.name == "preproc"
-        assert wf.base_dir == op.join(proj_info.cache_dir, exp_info.name)
+        assert wf.base_dir == op.join(info.cache_dir, info.experiment_name)
 
         # Check root directory of output
         template_out = wf.get_node("template_output")
-        assert template_out.inputs.base_directory == proj_info.proc_dir
+        assert template_out.inputs.base_directory == info.proc_dir
         timeseries_out = wf.get_node("timeseries_output")
-        assert timeseries_out.inputs.base_directory == proj_info.proc_dir
+        assert timeseries_out.inputs.base_directory == info.proc_dir
 
         # Check the list of nodes we expect
         expected_nodes = ["subject_source", "session_source", "run_source",
@@ -59,9 +56,8 @@ class TestPreprocWorkflow(object):
 
     def test_preproc_iterables(self, lyman_info):
 
-        proj_info = lyman_info["proj_info"]
-        scan_info = proj_info["scan_info"]
-        exp_info = lyman_info["exp_info"]
+        info = lyman_info["info"]
+        scan_info = info.scan_info
 
         # -- Test full iterables
 
@@ -86,9 +82,7 @@ class TestPreprocWorkflow(object):
 
         # -- Test iterables as set in workflow
 
-        wf = preproc.define_preproc_workflow(
-            proj_info, exp_info, ["subj01", "subj02"], None,
-        )
+        wf = preproc.define_preproc_workflow(info, ["subj01", "subj02"], None)
 
         subject_source = wf.get_node("subject_source")
         assert subject_source.iterables == ("subject", iterables[0])
@@ -153,9 +147,9 @@ class TestPreprocWorkflow(object):
         subject = template["subject"]
         session, run = "sess01", "run01"
         run_tuple = subject, session, run
-        exp_name = template["exp_info"].name
-        sb_template = template["proj_info"].sb_template
-        ts_template = template["proj_info"].ts_template
+        exp_name = template["info"].experiment_name
+        sb_template = template["info"].sb_template
+        ts_template = template["info"].ts_template
         crop_frames = 2
 
         affine = np.array([[-2, 0, 0, 10],
@@ -186,7 +180,7 @@ class TestPreprocWorkflow(object):
             proc_dir=template["proc_dir"],
             experiment=exp_name,
             sb_template=sb_template,
-            ts_template=template["proj_info"].ts_template,
+            ts_template=template["info"].ts_template,
             crop_frames=crop_frames,
         ).run().outputs
 
@@ -243,8 +237,8 @@ class TestPreprocWorkflow(object):
         session = "sess01"
         session_tuple = subject, session
 
-        fm_template = template["proj_info"].fm_template
-        phase_encoding = template["proj_info"].phase_encoding
+        fm_template = template["info"].fm_template
+        phase_encoding = template["info"].phase_encoding
 
         func_dir = template["data_dir"].join(subject).join("func")
 

--- a/lyman/workflows/tests/test_template.py
+++ b/lyman/workflows/tests/test_template.py
@@ -10,21 +10,19 @@ class TestTemplateWorkflow(object):
 
     def test_template_workflow_creation(self, lyman_info):
 
-        proj_info = lyman_info["proj_info"]
+        info = lyman_info["info"]
         subjects = lyman_info["subjects"]
 
-        wf = define_template_workflow(
-            proj_info, subjects
-        )
+        wf = define_template_workflow(info, subjects)
 
         # Check basic information about the workflow
         assert isinstance(wf, nipype.Workflow)
         assert wf.name == "template"
-        assert wf.base_dir == proj_info.cache_dir
+        assert wf.base_dir == info.cache_dir
 
         # Check root directory of output
         template_out = wf.get_node("template_output")
-        assert template_out.inputs.base_directory == proj_info.proc_dir
+        assert template_out.inputs.base_directory == info.proc_dir
 
         # Check the list of nodes we expect
         expected_nodes = ["subject_source", "template_input",

--- a/scripts/lyman
+++ b/scripts/lyman
@@ -56,7 +56,7 @@ def add_subparser(subparsers, name, help, parameterization):
 
 if __name__ == "__main__":
 
-    from lyman.frontend import (lyman_info, determine_subjects, execute)
+    import lyman
     from lyman.workflows.template import define_template_workflow
     from lyman.workflows.preproc import define_preproc_workflow
     from lyman.workflows.model import (define_model_fit_workflow,
@@ -113,8 +113,8 @@ if __name__ == "__main__":
     subject = getattr(args, "subject", None)
     session = getattr(args, "session", None)
 
-    info = lyman_info(experiment, model)
-    subjects = determine_subjects(args.subject)
+    info = lyman.info(experiment, model)
+    subjects = lyman.subjects(args.subject)
     sessions = session
     qc = args.qc
 
@@ -124,16 +124,16 @@ if __name__ == "__main__":
 
     if stage == "template":
         wf = define_template_workflow(info, subjects, qc)
-        execute(wf, args, info)
+        lyman.execute(wf, args, info)
 
     if stage == "preproc":
         wf = define_preproc_workflow(info, subjects, sessions, qc)
-        execute(wf, args, info)
+        lyman.execute(wf, args, info)
 
     if stage in ["model", "model-fit"]:
         wf = define_model_fit_workflow(info, subjects, sessions, qc)
-        execute(wf, args, info)
+        lyman.execute(wf, args, info)
 
     if stage in ["model", "model-res"]:
         wf = define_model_results_workflow(info, subjects, qc)
-        execute(wf, args, info)
+        lyman.execute(wf, args, info)

--- a/scripts/lyman
+++ b/scripts/lyman
@@ -1,63 +1,65 @@
 #! /usr/bin/env python
 import argparse
-
 import matplotlib
 matplotlib.use("Agg")
 
-from lyman.frontend import execute_workflow
 
+def add_subparser(subparsers, name, help, parameterization):
 
-def add_subject(parser):
-    parser.add_argument("-s", "--subject",
-                        nargs="*",
-                        metavar="id",
-                        help="subject id(s)")
+    parser = subparsers.add_parser(name, help=help)
 
+    if "subject" in parameterization:
+        parser.add_argument("-s", "--subject",
+                            nargs="*",
+                            metavar="id",
+                            help="subject id(s)")
 
-def add_session(parser):
-    parser.add_argument("--session",
-                        nargs="*",
-                        metavar="sess",
-                        help="scanning session(s) for single subject")
+    if "session" in parameterization:
+        parser.add_argument("--session",
+                            nargs="*",
+                            metavar="sess",
+                            help="scanning session(s) for single subject")
 
+    if "experiment" in parameterization:
+        parser.add_argument("-e", "--experiment",
+                            metavar="name",
+                            help="experiment name")
 
-def add_experiment(parser):
-    parser.add_argument("-e", "--experiment",
-                        metavar="name",
-                        help="experiment name")
+    if "model" in parameterization:
+        parser.add_argument("-m", "--model",
+                            metavar="name",
+                            help="model name")
 
-
-def add_model(parser):
-    parser.add_argument("-m", "--model",
-                        metavar="name",
-                        help="model name")
-
-
-def add_execution(parser):
-    parser.add_argument("-p", "--plugin",
-                        metavar="name",
-                        help="nipype execution plugin")
-    parser.add_argument("-n", "--nprocs",
+    parser.add_argument("-n", "--n-procs",
                         type=int,
+                        default=4,
                         metavar="number",
                         help="size of multiprocessing pool")
-    parser.add_argument("-g", "--graph",
-                        action="store_true",  # TODO make this take a filename
-                        help="write graph instead of executing")
+    parser.add_argument("--graph",
+                        const=True,
+                        metavar="<fname>",
+                        help="create graph image instead of executing")
+    parser.add_argument("--debug",
+                        action="store_strue",
+                        help="enable nipype debug mode")
     parser.add_argument("--clear-cache",
                         action="store_true",
                         help="remove existing cache directory before running")
     parser.add_argument("--no-qc",
                         dest="qc", action="store_false",
                         help="don't connect qc nodes")
-    parser.add_argument("--no-run",
-                        dest="run", action="store_false",
-                        help="do everything but actually execute the workflow")
-
-    # TODO add debug mode that preserves cache directory and all outputs
+    parser.add_argument("--no-exec",
+                        dest="execute", action="store_false",
+                        help="define the workflow but do not execute it")
 
 
 if __name__ == "__main__":
+
+    from lyman.frontend import (lyman_info, determine_subjects, execute)
+    from .workflows.template import define_template_workflow
+    from .workflows.preproc import define_preproc_workflow
+    from .workflows.model import (define_model_fit_workflow,
+                                  define_model_results_workflow)
 
     parser = argparse.ArgumentParser(prog="lyman")
     subparsers = parser.add_subparsers(help="processing stage",
@@ -65,50 +67,69 @@ if __name__ == "__main__":
 
     # ---
 
-    template = subparsers.add_parser("template",
-                                     help="functional template definition")
-    add_subject(template)
-    add_execution(template)
+    add_subparser(
+        subparsers,
+        "template",
+        "functional template definition",
+        ["subject"],
+    )
 
-    # ---
+    add_subparser(
+        subparsers,
+        "preproc",
+        "functional preprocessing",
+        ["subject", "session", "experiment"],
+    )
 
-    preproc = subparsers.add_parser("preproc",
-                                    help="functional preprocessing")
-    add_subject(preproc)
-    add_session(preproc)
-    add_experiment(preproc)
-    add_execution(preproc)
+    add_subparser(
+        subparsers,
+        "model",
+        "fit univariate GLM and estimate contrasts",
+        ["subject", "session", "experiment", "model"],
+    )
 
-    # ---
+    add_subparser(
+        subparsers,
+        "model-fit",
+        "fit univariate GLM",
+        ["subject", "session", "experiment", "model"],
+    )
 
-    # TODO a nice API would be something like model, model-fit, and model-res
-    # We typically will want to do both, but want flexibility not to
-    model_all = subparsers.add_parser("model",
-                                      help=("fit univariate GLM "
-                                            "and estimate contrasts"))
-    add_subject(model_all)
-    add_experiment(model_all)
-    add_model(model_all)
-    add_session(model_all)
-    add_execution(model_all)
-
-    model_fit = subparsers.add_parser("model-fit",
-                                      help="fit univariate GLM")
-    add_subject(model_fit)
-    add_experiment(model_fit)
-    add_model(model_fit)
-    add_session(model_fit)
-    add_execution(model_fit)
-
-    model_res = subparsers.add_parser("model-res",
-                                      help="estimate univariate contrats")
-    add_subject(model_res)
-    add_experiment(model_res)
-    add_model(model_res)
-    add_execution(model_res)
+    add_subparser(
+        subparsers,
+        "model-res",
+        "estimate univariate contrasts",
+        ["subject", "experiment", "model"],
+    )
 
     # ---
 
     args = parser.parse_args()
+    stage = args.stage
 
-    execute_workflow(args)
+    info = lyman_info(args.experiment, args.model)
+    subjects = determine_subjects(args.subject)
+    sessions = args.session
+    qc = args.qc
+
+    if len(subjects) > 1 and sessions is not None:
+        raise RuntimeError("Can only specify session for single subject")
+
+    if stage == "template":
+        wf = define_template_workflow(info, subjects, qc)
+        execute(wf, args, info)
+
+    else:
+
+        if stage == "preproc":
+            wf = define_preproc_workflow(info, subjects, sessions, qc)
+            execute(wf, args, info)
+
+        else:
+
+            if stage in ["model", "model-fit"]:
+                wf = define_model_fit_workflow(info, subjects, sessions, qc)
+                execute(wf, args, info)
+            if stage in ["model", "model-res"]:
+                wf = define_model_results_workflow(info, subjects, qc)
+                execute(wf, args, info)

--- a/scripts/lyman
+++ b/scripts/lyman
@@ -106,21 +106,17 @@ if __name__ == "__main__":
     # ---
 
     args = parser.parse_args()
+
     stage = args.stage
+    qc = args.qc
 
     experiment = getattr(args, "experiment", None)
     model = getattr(args, "model", None)
-    subject = getattr(args, "subject", None)
-    session = getattr(args, "session", None)
+    subjects = getattr(args, "subject", None)
+    sessions = getattr(args, "session", None)
 
     info = lyman.info(experiment, model)
-    subjects = lyman.subjects(args.subject)
-    sessions = session
-    qc = args.qc
-
-    # TODO best place for this? (Maybe move into determine_subjects?)
-    if len(subjects) > 1 and sessions is not None:
-        raise RuntimeError("Can only specify session for single subject")
+    subjects = lyman.subjects(subjects, sessions)
 
     if stage == "template":
         wf = define_template_workflow(info, subjects, qc)

--- a/scripts/lyman
+++ b/scripts/lyman
@@ -112,6 +112,7 @@ if __name__ == "__main__":
     sessions = args.session
     qc = args.qc
 
+    # TODO best place for this? (Maybe move into determine_subjects?)
     if len(subjects) > 1 and sessions is not None:
         raise RuntimeError("Can only specify session for single subject")
 
@@ -119,17 +120,14 @@ if __name__ == "__main__":
         wf = define_template_workflow(info, subjects, qc)
         execute(wf, args, info)
 
-    else:
+    if stage == "preproc":
+        wf = define_preproc_workflow(info, subjects, sessions, qc)
+        execute(wf, args, info)
 
-        if stage == "preproc":
-            wf = define_preproc_workflow(info, subjects, sessions, qc)
-            execute(wf, args, info)
+    if stage in ["model", "model-fit"]:
+        wf = define_model_fit_workflow(info, subjects, sessions, qc)
+        execute(wf, args, info)
 
-        else:
-
-            if stage in ["model", "model-fit"]:
-                wf = define_model_fit_workflow(info, subjects, sessions, qc)
-                execute(wf, args, info)
-            if stage in ["model", "model-res"]:
-                wf = define_model_results_workflow(info, subjects, qc)
-                execute(wf, args, info)
+    if stage in ["model", "model-res"]:
+        wf = define_model_results_workflow(info, subjects, qc)
+        execute(wf, args, info)

--- a/scripts/lyman
+++ b/scripts/lyman
@@ -37,10 +37,11 @@ def add_subparser(subparsers, name, help, parameterization):
                         help="size of multiprocessing pool")
     parser.add_argument("--graph",
                         const=True,
+                        nargs="?",
                         metavar="<fname>",
                         help="create graph image instead of executing")
     parser.add_argument("--debug",
-                        action="store_strue",
+                        action="store_true",
                         help="enable nipype debug mode")
     parser.add_argument("--clear-cache",
                         action="store_true",
@@ -56,10 +57,10 @@ def add_subparser(subparsers, name, help, parameterization):
 if __name__ == "__main__":
 
     from lyman.frontend import (lyman_info, determine_subjects, execute)
-    from .workflows.template import define_template_workflow
-    from .workflows.preproc import define_preproc_workflow
-    from .workflows.model import (define_model_fit_workflow,
-                                  define_model_results_workflow)
+    from lyman.workflows.template import define_template_workflow
+    from lyman.workflows.preproc import define_preproc_workflow
+    from lyman.workflows.model import (define_model_fit_workflow,
+                                       define_model_results_workflow)
 
     parser = argparse.ArgumentParser(prog="lyman")
     subparsers = parser.add_subparsers(help="processing stage",
@@ -107,9 +108,14 @@ if __name__ == "__main__":
     args = parser.parse_args()
     stage = args.stage
 
-    info = lyman_info(args.experiment, args.model)
+    experiment = getattr(args, "experiment", None)
+    model = getattr(args, "model", None)
+    subject = getattr(args, "subject", None)
+    session = getattr(args, "session", None)
+
+    info = lyman_info(experiment, model)
     subjects = determine_subjects(args.subject)
-    sessions = args.session
+    sessions = session
     qc = args.qc
 
     # TODO best place for this? (Maybe move into determine_subjects?)

--- a/testing/conda_requirements.txt
+++ b/testing/conda_requirements.txt
@@ -6,3 +6,5 @@ traits
 networkx
 pyyaml
 pytest
+pydotplus
+graphviz


### PR DESCRIPTION
This PR fundamentally reworks how interaction with lyman happens and has substantial consequences both for users of the library and for the internal details.

Some of these changes were prototyped earlier in the overhaul but I'll document them here.

### Command line interface:

- The command line interface now consists of a single executable script, called `lyman`. This script has several sub-modes that control various stages of processing. The sub-modes are roughly analogous to the `-workflow` option in `run_fmri.py`, but you can't specify multiple workflows at once (however the workflows have been condensed such that you generally wouldn't want to). This simplifies the command-line help because now you only see the command-line options that pertain to the workflow you are going to execute.
- The plan is also to handle other kinds of operations that may not be directly tied to a nipype workflow through the same interface (i.e. generating roi masks, launching Freeview sessions with various lyman results images, probably whatever is going to replace ziegler), but none of that is implemented yet.

### Frontend library functions:

- The `gather_project_info` and `gather_experiment_info` functions have been condensed into a single `info` function that returns an object with all analysis parameters (as traits), which includes experiment- and model-level information if corresponding names are provided.
- The `determine_subjects` function has been renamed into `subjects` and additionally now understands string-typed arguments instead of requiring a single-element list.

### Analysis parameter specification:

- Specifying information that controls the what and how of processing is broadly similar to lyman 1.0. There is the concept of a "lyman directory" where python files are written with various parameters.
- As previously, there is a `project.py` that stores general information related to a project. The `setup_project.py` interface for generating this file has been deprecated, however.
- There are two more levels of information: experiment and model. This is similar to before (with the concept of an altmodel) but now they are formally separated, and both are required. There is a one-to-many relation between experiments and models, although experiment parameters that are relevant at the model stage (e.g. smoothing kernel size) can be defined at the experiment level and the various model files will inherit them.
- Information specification is now handled with traits, similar to nipype interfaces themselves, meaning errors will be caught earlier and with more meaningful exceptions. This will also simplify maintaing a single source for documentation of parameters, default values, and semantic help.
-Many parameters have been added, removed, or renamed to reflect changes in the analysis workflows.

### Subject identification:

- Identifying subjects is a little bit more complicated than in lyman 1.0. There is a new required file in the lyman directory, `scans.yaml`. Note that this file is written in [yaml](https://en.wikipedia.org/wiki/YAML), not Python.
- The file contains specifiers for every subject, session, and run (organized into experiment). An advantage is that input files are no longer globbed (matched with a `*`), so this way requires a little bit more work but is a little less error prone. Additionally, the files are identified this way throughout the lyman processing workflows. So it is easier in 2.0 to, say, exclude a single run from downstream analyses if it is found to have an idiosyncratic artifact.
- The format of the file is complicated to explain, though fairly straightforward when you see an example. The file is essentially a set of nested dictionaries: a dictionary mapping subject names to a a dictionary mapping session ids to a dictionary mapping experiment names to a list of run ids. That is, something like this:
```
subj01:
  sess01:
    exp_alpha: [run01, run02]
  sess02:
    exp_alpha: [run01]
    exp_beta: [run01, run02]
subj02:
  sess01:
    exp_beta: [run01, run03]
```
- Note that the session and run identifiers can be any string: instead of "sess01" you could use a date and instead of "run01" you could use a time.
- It's no longer necessary to add a `subjects.txt` file in the lyman directory: the `scans.yaml` file provides the default set of all subjects. However you can still add text files with subsets of subjects.

Closes #112 and #123