### PR TITLE
Add design matrix construction in lyman

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ install:
   - conda create -q -n testenv pip python=$TRAVIS_PYTHON_VERSION
   - source activate testenv
   - conda install --yes --file testing/conda_requirements.txt
+  # TODO if we use conda-forge can install everything with conda (I think)
   - pip install -r testing/pip_requirements.txt
   - pip install git+https://github.com/nipy/nipype  # Needed until nipype 0.14
   - pip install .

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,11 @@ before_install:
   - conda config --set always_yes yes --set changeps1 no
   - conda update -q conda
   - conda info -a
-  - export FSLDIR=`pwd`/testing  # TODO do we need this?
-  - export SUBJECTS_DIR=`pwd`/testing
   - cp testing/matplotlibrc .
+
+  # TODO I think these lines and the related files can be removed
+  - export FSLDIR=`pwd`/testing
+  - export SUBJECTS_DIR=`pwd`/testing
 
 install:
   - conda create -q -n testenv pip python=$TRAVIS_PYTHON_VERSION
@@ -21,11 +23,6 @@ install:
   - conda install --yes --file testing/conda_requirements.txt
   - pip install -r testing/pip_requirements.txt
   - pip install git+https://github.com/nipy/nipype  # Needed until nipype 0.14
-
-  # Needed until overhal is finished
-  - conda install --yes seaborn scikit-learn
-  - pip install moss==0.5.0
-
   - pip install .
 
 before_script:

--- a/conftest.py
+++ b/conftest.py
@@ -1,3 +1,4 @@
+from copy import deepcopy
 import numpy as np
 import pandas as pd
 import nibabel as nib
@@ -309,31 +310,50 @@ def modelfit(timeseries):
 @pytest.fixture()
 def modelres(modelfit):
 
-    seed = sum(map(ord, "modelfit"))
+    seed = sum(map(ord, "modelres"))
     rs = np.random.RandomState(seed)
 
     vol_shape = modelfit["vol_shape"]
     affine = modelfit["affine"]
-    n_contrasts = len(modelfit["info"].contrasts)
 
-    model_dir = modelfit["model_dir"]
+    name_lists = [
+        ["a", "b", "c", "a-b"],
+        ["a", "b", "a-b"],
+    ]
+    run_ns = [len(n_list) for n_list in name_lists]
 
-    contrast_data = rs.normal(0, 5, vol_shape + (n_contrasts,))
-    contrast_file = str(model_dir.join("contrast.nii.gz"))
-    nib.save(nib.Nifti1Image(contrast_data, affine), contrast_file)
+    exp_name = modelfit["info"].experiment_name
+    model_name = modelfit["info"].model_name
+    session = "s1"
+    runs = ["r1", "r2"]
 
-    variance_data = rs.uniform(0, 5, vol_shape + (n_contrasts,))
-    variance_file = str(model_dir.join("variance.nii.gz"))
-    nib.save(nib.Nifti1Image(variance_data, affine), variance_file)
+    model_dir_base = (modelfit["proc_dir"]
+                      .join(modelfit["subject"])
+                      .join(exp_name)
+                      .join(model_name))
+    model_dirs = [
+        model_dir_base.mkdir("{}_{}".format(session, run))
+        for run in runs
+    ]
 
-    tstat_data = rs.normal(0, 2, vol_shape + (n_contrasts,))
-    tstat_file = str(model_dir.join("tstat.nii.gz"))
-    nib.save(nib.Nifti1Image(tstat_data, affine), tstat_file)
+    con_data = [rs.normal(0, 5, vol_shape + (n,)) for n in run_ns]
+    con_files = [str(d.join("contrast.nii.gz")) for d in model_dirs]
+    for d, f in zip(con_data, con_files):
+        nib.save(nib.Nifti1Image(d, affine), f)
+
+    var_data = [rs.uniform(0, 5, vol_shape + (n,)) for n in run_ns]
+    var_files = [str(d.join("variance.nii.gz")) for d in model_dirs]
+    for d, f in zip(var_data, var_files):
+        nib.save(nib.Nifti1Image(d, affine), f)
+
+    name_files = [str(d.join("contrast.txt")) for d in model_dirs]
+    for l, f in zip(name_lists, name_files):
+        np.savetxt(f, l, "%s")
 
     modelfit.update(
-        contrast_file=contrast_file,
-        variance_file=variance_file,
-        tstat_file=tstat_file,
+        contrast_files=con_files,
+        variance_files=var_files,
+        name_files=name_files,
     )
     return modelfit
 

--- a/conftest.py
+++ b/conftest.py
@@ -60,6 +60,7 @@ def lyman_info(tmpdir):
         smooth_fwhm=4,
         surface_smoothing=True,
         hpf_cutoff=10,
+        hrf_derivative=False,
         save_residuals=True,
         contrasts=contrasts,
     )

--- a/lyman/frontend.py
+++ b/lyman/frontend.py
@@ -145,7 +145,12 @@ class ModelInfo(ExperimentInfo):
         after model fitting.
         """),
     )
-    # TODO HRF model and params
+    hrf_derivative = Bool(
+        True,
+        desc=dedent("""
+        If True, include the temporal derivative of the HRF model.
+        """),
+    )
     # TODO model confounds and artifact-related params
     # TODO parameter names to filter the design and generate default contrasts?
     contrasts = List(

--- a/lyman/glm.py
+++ b/lyman/glm.py
@@ -166,7 +166,7 @@ def conditions_to_regressors(name, conditions, hrf_model,
     hires_input = pd.Series(hires_input, name=name)
     hires_output = hrf_model.transform(hires_input)
 
-    # TODO this is bad!
+    # TODO It's annoying that we have to do this!
     if isinstance(hires_output, (pd.Series, pd.DataFrame)):
         hires_output = (hires_output,)
 
@@ -174,7 +174,6 @@ def conditions_to_regressors(name, conditions, hrf_model,
     output = []
     for hires_col in hires_output:
         # TODO having to do this is a pain!
-        # TODO also this doesn't handle 1D outputs:
         if hires_col is None:
             output.append(None)
             continue
@@ -313,7 +312,12 @@ def contrast_matrix(contrast, design_matrix):
         Contrast weights with regressor names as the index.
 
     """
-    pass
+    columns = design_matrix.columns.tolist()
+    C = np.zeros(len(columns))
+    _, names, weights = contrast
+    for name, weight in zip(names, weights):
+        C[columns.index(name)] = weight
+    return C
 
 
 def prewhiten_image_data(ts_img, mask_img, X, smooth_fwhm=5):

--- a/lyman/glm.py
+++ b/lyman/glm.py
@@ -275,6 +275,7 @@ def build_design_matrix(conditions=None, hrf_model=None,
         condition_columns = pd.concat(condition_columns, axis=1)
 
         # High-pass filter the condition information
+        # TODO revisit to decide whether only conditions should be filtered
         if hpf_matrix is not None:
             prefilter_means = condition_columns.mean()
             condition_columns.values[:] = hpf_matrix.dot(condition_columns)
@@ -292,6 +293,8 @@ def build_design_matrix(conditions=None, hrf_model=None,
         columns = ["art{:02d}".format(i) for i in range(artifacts.sum())]
         indicators = pd.DataFrame(indicators, index, columns, np.float)
         design_components.append(indicators)
+
+    # TODO Add polynomial regressors as alternative to HPF?
 
     # -- Final assembly
     X = pd.concat(design_components, axis=1)

--- a/lyman/glm.py
+++ b/lyman/glm.py
@@ -11,7 +11,7 @@ from .utils import image_to_matrix, matrix_to_image
 class HRFModel(object):
 
     def transform(self, input):
-        """Generate a predicted response ot the input."""
+        """Generate a basis set for the predicted response to the input."""
         raise NotImplementedError
 
 
@@ -91,22 +91,91 @@ class GammaHRF(HRFModel):
             if dy is not None:
                 dy = pd.Series(dy, input.index, name=input.name + "-dydt")
 
-        # TODO is always returning a pair helpful or a nuisance?
-        # upside: when building the design matrix, a flat column list can be
-        # extended, and then pd.concat will drop the Nones
-        # downside: when just interested in the cannonical prediction, it's
-        # a minor pain to have to index into the return value
+        # TODO Is always returning a pair helpful or a nuisance?
+        # Upside: when building the design matrix, a flat column list can be
+        # extended, and then pd.concat will drop the Nones.
+        # Downside: when just interested in the canonical prediction, it's
+        # a minor pain to have to index into the return value.
         # in any case, transform() should probably have the same behavior
         # as kernel in terms of what it returns
 
         return y, dy
 
 
-def build_design_matrix(events=None, hrf_model=None,
+def conditions_to_regressors(conditions, hrf_model, n_tp, tr, res, shift):
+    """Generate design matrix columns from information about event occurrence.
+
+    Parameters
+    ----------
+    conditions : dataframe
+        Must have onset (in seconds), duration (in seconds), and value (in
+        arbitrary units) columns; and should correspond to event occurrences.
+    hrf_model : HRFModel object
+        Object that implements `.transform()` to return a basis set for the
+        predicted response.
+    n_tp : int
+        Number of time points in the final output.
+    tr : float
+        Time resolution of the output regressor, in seconds.
+    res : float
+        Sampling resolution at which to construct the regressor and perform
+        convolution with the HRF model.
+    shift : float
+        Proportion of the TR to shift the predicted response when downsampling
+        to the output resolution.
+
+    Returns
+    -------
+    regressors : column(s)
+        One or more output regressors that will form columns in the design
+        matrix corresponding to this event type.
+
+    """
+    pass
+
+
+def build_design_matrix(conditions=None, hrf_model=None,
                         regressors=None, artifacts=None,
                         n_tp=None, tr=1, res=60, shift=.5,
                         hpf_matrix=None, demean=True):
+    """Use design information to build a matrix for a BOLD time series GLM.
 
+    Parameters
+    ----------
+    conditions : dataframe
+        Must have condition (a string), onset (in seconds), duration (in
+        seconds), and value (in arbitrary units) columns; rows should
+        correspond to event occurrences.
+    hrf_model : HRFModel object
+        Object that implements `.transform()` to return a basis set for the
+        predicted response.
+    regressors : DataFrame
+        Additional columns to include in the design matrix without any
+        transformation (aside from optional de-meaning).
+    artifacts : boolean series
+        A Series indicating which row should have indicator regressors
+        included in the design matrix to account for signal artifacts.
+    n_tp : int
+        The number of timepoints in the
+    tr : float
+        Time resolution of the output regressors, in seconds.
+    res : float
+        Sampling resolution at which to construct the condition regressors and
+        perform convolution with the HRF model.
+    shift : float
+        Proportion of the TR to shift the predicted response when downsampling
+        to the output resolution.
+    hpf_matrix : n_tp x n_tp array
+        Matrix for high-pass filtering the condition regressors.
+    demean : bool
+        If True, each column in the output matrix will be mean-centered.
+
+    Returns
+    -------
+    X : dataframe
+        Design matrix with timepoints in rows and regressors in columns.
+
+    """
     pass
 
 

--- a/lyman/tests/test_glm.py
+++ b/lyman/tests/test_glm.py
@@ -116,7 +116,22 @@ class TestHRFs(object):
 
 class TestDesignMatrix(object):
 
-    pass
+    @pytest.fixture
+    def random(self):
+
+        seed = sum(map(ord, "design_matrix"))
+        return np.random.RandomState(seed)
+
+    @pytest.fixture
+    def conditions(self):
+
+        conditions = pd.DataFrame(dict(
+            condition=["a", "b", "a", "b"],
+            onset=[0, 12, 24, 36],
+            duration=[2, 2, 2, 2],
+            value=[1, 1, 1, 1],
+        ))
+        return conditions
 
 
 class TestLinearModel(object):

--- a/lyman/tests/test_glm.py
+++ b/lyman/tests/test_glm.py
@@ -1,5 +1,6 @@
 from __future__ import division
 import os.path as op
+from itertools import product
 import numpy as np
 import pandas as pd
 import nibabel as nib
@@ -35,8 +36,14 @@ class TestHRFs(object):
         with pytest.raises(NotImplementedError):
             glm.HRFModel().transform(None)
 
+    def test_identity(self, input):
+
+        output = glm.IdentityHRF().transform(input)
+        assert np.array_equal(output, input)
+
     @pytest.mark.parametrize(
-        "res,duration", [(10, 20), (24, 42)])
+        "res,duration",
+        product((10, 20), (24, 42)))
     def test_gamma_hrf_kernel_size(self, res, duration):
 
         hrf = glm.GammaHRF(res=res, duration=duration)
@@ -132,6 +139,107 @@ class TestDesignMatrix(object):
             value=[1, 1, 1, 1],
         ))
         return conditions
+
+    @pytest.fixture
+    def regressors(self, random):
+
+        data = random.normal(2, 1, (48, 3))
+        columns = ["x", "y", "z"]
+        regressors = pd.DataFrame(data, columns=columns)
+        return regressors
+
+    @pytest.fixture
+    def artifacts(self, random):
+
+        return pd.Series(random.rand(48) < .1)
+
+    @pytest.mark.parametrize(
+        "n_tp,tr,deriv",
+        product((24, 28), (1, 2), (False, True)))
+    def test_design_shape_and_index(self, conditions, tr, n_tp, deriv):
+
+        X = glm.build_design_matrix(conditions, glm.GammaHRF(deriv),
+                                    n_tp=n_tp, tr=tr)
+
+        assert isinstance(X, pd.DataFrame)
+        assert X.shape == (n_tp, 2 * (2 if deriv else 1))
+
+        tps = np.arange(0, n_tp * tr, tr)
+        assert np.array_equal(X.index.values, tps)
+
+    def test_design_contents(self, conditions):
+
+        n_tp, tr = 48, 1
+        X = glm.build_design_matrix(conditions, glm.IdentityHRF(),
+                                    n_tp=n_tp, tr=tr, demean=False)
+
+        expected_a = np.zeros(n_tp)
+        expected_a[[0, 1, 24, 25]] = 1
+        assert np.array_equal(X["a"].values, expected_a)
+
+        n_tp, tr = 24, 2
+        X = glm.build_design_matrix(conditions, glm.IdentityHRF(),
+                                    n_tp=n_tp, tr=tr, demean=False)
+
+        expected_a = np.zeros(n_tp)
+        expected_a[[0 // tr, 24 // tr]] = 1
+        assert isinstance(X, pd.DataFrame)
+        assert np.array_equal(X["a"].values, expected_a)
+
+    def test_design_regressors(self, conditions, regressors):
+
+        cols = regressors.columns.tolist()
+
+        X = glm.build_design_matrix(regressors=regressors)
+        assert X.columns.tolist() == cols
+        assert np.array_equal(X[cols], regressors - regressors.mean())
+
+        X = glm.build_design_matrix(conditions, regressors=regressors)
+        assert X.columns.tolist() == ["a", "b"] + cols
+        assert np.array_equal(X[cols], regressors - regressors.mean())
+
+        X = glm.build_design_matrix(regressors=regressors, demean=False)
+        assert np.array_equal(X[cols], regressors)
+
+    def test_design_artifacts(self, conditions, artifacts):
+
+        cols = ["art{:02d}".format(i) for i in range(artifacts.sum())]
+
+        X = glm.build_design_matrix(artifacts=artifacts)
+        assert X.columns.tolist() == cols
+        assert X.shape == (48, artifacts.sum())
+
+        X = glm.build_design_matrix(conditions, artifacts=artifacts)
+        assert X.columns.tolist() == ["a", "b"] + cols
+
+    def test_n_tp_errors(self, conditions, regressors, artifacts):
+
+        with pytest.raises(ValueError):
+            glm.build_design_matrix(regressors=regressors, n_tp=20)
+
+        with pytest.raises(ValueError):
+            glm.build_design_matrix(artifacts=artifacts, n_tp=20)
+
+        with pytest.raises(ValueError):
+            glm.build_design_matrix(regressors=regressors,
+                                    artifacts=artifacts.iloc[:20])
+
+    def test_hpf(self, conditions):
+
+        n_tp = 48
+        F = glm.highpass_filter_matrix(n_tp, 20, 1)
+        X = glm.build_design_matrix(conditions, hpf_matrix=F, n_tp=n_tp)
+        assert len(X) == len(F)
+
+    def test_condition_defaults(self, conditions):
+
+        conditions.loc[:, "duration"] = 0
+        conditions.loc[:, "value"] = 1
+        min_cols = ["condition", "onset"]
+
+        X1 = glm.build_design_matrix(conditions, n_tp=48)
+        X2 = glm.build_design_matrix(conditions[min_cols].copy(), n_tp=48)
+        assert np.array_equal(X1.values, X2.values)
 
 
 class TestLinearModel(object):

--- a/lyman/tests/test_glm.py
+++ b/lyman/tests/test_glm.py
@@ -242,6 +242,43 @@ class TestDesignMatrix(object):
         assert np.array_equal(X1.values, X2.values)
 
 
+class TestContrastMatrix(object):
+
+    @pytest.fixture
+    def random(self):
+
+        seed = sum(map(ord, "contrast_matrix"))
+        return np.random.RandomState(seed)
+
+    @pytest.fixture
+    def design(self, random):
+
+        cols = list("abcd")
+        return pd.DataFrame(random.normal(0, 1, (48, 4)), columns=cols)
+
+    def test_contrast_matrix(self, design):
+
+        contrast = ("a", ["a"], [1])
+        C = glm.contrast_matrix(contrast, design)
+        assert np.array_equal(C, [1, 0, 0, 0])
+
+        contrast = ("c", ["c"], [1])
+        C = glm.contrast_matrix(contrast, design)
+        assert np.array_equal(C, [0, 0, 1, 0])
+
+        contrast = ("a-c", ["a", "c"], [1, -1])
+        C = glm.contrast_matrix(contrast, design)
+        assert np.array_equal(C, [1, 0, -1, 0])
+
+        contrast = ("a-c", ["c", "a"], [-1, 1])
+        C = glm.contrast_matrix(contrast, design)
+        assert np.array_equal(C, [1, 0, -1, 0])
+
+        contrast = ("a-bd", ["a", "b", "d"], [1, -.5, -.5])
+        C = glm.contrast_matrix(contrast, design)
+        assert np.array_equal(C, [1, -.5, 0, -.5])
+
+
 class TestLinearModel(object):
 
     @pytest.fixture()

--- a/lyman/tests/test_utils.py
+++ b/lyman/tests/test_utils.py
@@ -1,6 +1,7 @@
 import os.path as op
 import json
 import numpy as np
+import matplotlib.pyplot as plt
 import nibabel as nib
 
 from nipype.interfaces.base import traits, TraitedSpec, Bunch
@@ -96,9 +97,19 @@ class TestLymanInterface(object):
         ifc = utils.LymanInterface()
         ifc.write_visualization(out_field, out_path, viz)
 
-        assert op.exists("test.png")
+        assert op.exists(out_path)
         assert ifc._results == {out_field: op.join(execdir, out_path)}
         assert viz.closed
+
+        out_field = "test_figure"
+        out_path = "test_figure.png"
+
+        f = plt.figure()
+        ifc = utils.LymanInterface()
+        ifc.write_visualization(out_field, out_path, f)
+
+        assert op.exists(out_path)
+        assert ifc._results == {out_field: op.join(execdir, out_path)}
 
     def test_submit_cmdline(self, execdir):
 

--- a/lyman/utils.py
+++ b/lyman/utils.py
@@ -3,6 +3,7 @@ import subprocess as sp
 import json
 
 import numpy as np
+import matplotlib.pyplot as plt
 import nibabel as nib
 from nipype.interfaces.base import BaseInterface, TraitedSpec, traits
 
@@ -37,7 +38,11 @@ class LymanInterface(BaseInterface):
     def write_visualization(self, field, fname, viz):
         """Write a visualization to disk and assign path to output field."""
         fname = self.define_output(field, fname)
-        viz.savefig(fname, close=True)
+        if isinstance(viz, plt.Figure):
+            viz.savefig(fname, dpi=100)
+            plt.close(viz)
+        else:
+            viz.savefig(fname, close=True)
 
     def submit_cmdline(self, runtime, cmdline):
         """Submit a command-line job and capture the output."""

--- a/lyman/visualizations.py
+++ b/lyman/visualizations.py
@@ -674,3 +674,39 @@ class CarpetPlot(object):
                 ha="center", va="bottom", clip_on=False)
         ax.text(0, 103, "$-${}".format(vlim),
                 ha="center", va="top", clip_on=False)
+
+
+def plot_design_matrix(X):
+    """Show the design matrix as a transposed heatmap.
+
+    Parameters
+    ----------
+    X : dataframe
+        The design matrix with regressors in the columns.
+
+    Returns
+    -------
+    f : figure
+        The matplotlib figure with the heatmap drawn on the only axes.
+    """
+    X = X - X.min()
+    X = X / X.max()
+
+    n_col = X.shape[1]
+    figsize = 8, .5 * n_col
+    f, ax = plt.subplots(figsize=figsize)
+
+    ax.pcolormesh(X.T, cmap="gray")
+    ax.invert_yaxis()
+
+    for i in range(1, n_col):
+        ax.axhline(i, color="w", lw=1)
+
+    yticks = np.arange(n_col) + .5
+    ax.set_yticks(yticks)
+    ax.set_yticklabels(X.columns)
+    ax.set_xticks([])
+
+    f.tight_layout()
+
+    return f

--- a/lyman/workflows/model.py
+++ b/lyman/workflows/model.py
@@ -11,7 +11,7 @@ from nipype.interfaces.base import traits, TraitedSpec, Bunch
 
 from .. import glm, signals, surface
 from ..utils import LymanInterface, SaveInfo, image_to_matrix, matrix_to_image
-from ..visualizations import Mosaic, CarpetPlot
+from ..visualizations import Mosaic, CarpetPlot, plot_design_matrix
 
 
 def define_model_fit_workflow(info, subjects, sessions, qc=True):
@@ -566,10 +566,8 @@ class ModelFit(LymanInterface):
         self.write_visualization("resid_plot", "resid.png", p)
 
         # Plot the deisgn matrix
-        design_plot = self.define_output("design_plot", "design.png")
-        # TODO add to visualization module and fix
-        with open(design_plot, "w") as fid:
-            fid.write(" ")
+        f = plot_design_matrix(X)
+        self.write_visualization("design_plot", "design.png", f)
 
         # Plot the sigma squares image for QC
         error_m = Mosaic(mean_img, error_img, mask_img)

--- a/lyman/workflows/model.py
+++ b/lyman/workflows/model.py
@@ -161,7 +161,8 @@ def define_model_results_workflow(info, subjects, qc=True):
                              name="model_results",
                              joinsource="run_source",
                              joinfield=["contrast_files",
-                                        "variance_files"])
+                                        "variance_files",
+                                        "name_files"])
 
     # --- Data output
 
@@ -207,7 +208,8 @@ def define_model_results_workflow(info, subjects, qc=True):
             [("anat_file", "anat_file")]),
         (estimate_contrasts, model_results,
             [("contrast_file", "contrast_files"),
-             ("variance_file", "variance_files")]),
+             ("variance_file", "variance_files"),
+             ("name_file", "name_files")]),
 
         (run_source, save_info,
             [("run", "parameterization")]),
@@ -591,6 +593,7 @@ class EstimateContrasts(LymanInterface):
         contrast_file = traits.File(exists=True)
         variance_file = traits.File(exists=True)
         tstat_file = traits.File(exists=True)
+        name_file = traits.File(exists=True)
 
     def _run_interface(self, runtime):
 
@@ -605,6 +608,7 @@ class EstimateContrasts(LymanInterface):
         XtXinv = image_to_matrix(ols_img, mask_img)
 
         X = pd.read_csv(self.inputs.design_file)
+        param_names = X.columns
 
         # Reshape the matrix form data to what the glm functions expect
         # TODO the shape/orientation of model parameter matrices needs some
@@ -614,9 +618,13 @@ class EstimateContrasts(LymanInterface):
         XtXinv = XtXinv.reshape(n_ev, n_ev, n_vox).T
 
         # Obtain list of contrast matrices
-        # TODO handle contrasts with missing conditions
-        # and also add a contrast.txt file with names
-        C = [glm.contrast_matrix(c, X) for c in self.inputs.info["contrasts"]]
+        C = []
+        names = []
+        for contrast_spec in self.inputs.info["contrasts"]:
+            name, params, _ = contrast_spec
+            if set(params) <= set(param_names):
+                C.append(glm.contrast_matrix(contrast_spec, X))
+                names.append(name)
 
         # Estimate the contrasts, variances, and statistics in each voxel
         G, V, T = glm.iterative_contrast_estimation(B, SS, XtXinv, C)
@@ -628,6 +636,8 @@ class EstimateContrasts(LymanInterface):
         self.write_image("contrast_file", "contrast.nii.gz", contrast_img)
         self.write_image("variance_file", "variance.nii.gz", variance_img)
         self.write_image("tstat_file", "tstat.nii.gz", tstat_img)
+        name_file = self.define_output("name_file", "contrast.txt")
+        np.savetxt(name_file, names, "%s")
 
         return runtime
 
@@ -639,6 +649,7 @@ class ModelResults(LymanInterface):
         anat_file = traits.File(exists=True)
         contrast_files = traits.List(traits.File(exists=True))
         variance_files = traits.List(traits.File(exists=True))
+        name_files = traits.List(traits.File(exists=True))
 
     class output_spec(TraitedSpec):
         result_directories = traits.List(traits.Directory(exists=True))
@@ -651,7 +662,6 @@ class ModelResults(LymanInterface):
         anat_img = nib.load(self.inputs.anat_file)
         affine, header = anat_img.affine, anat_img.header
 
-        # TODO define contrasts properly accounting for missing EVs
         result_directories = []
         for i, contrast_tuple in enumerate(info.contrasts):
 
@@ -664,15 +674,19 @@ class ModelResults(LymanInterface):
             var_frames = []
 
             # Load the parameter and variance data for each run/contrast.
-            con_images = map(nib.load, self.inputs.contrast_files)
-            var_images = map(nib.load, self.inputs.variance_files)
+            con_images = [nib.load(f) for f in self.inputs.contrast_files]
+            var_images = [nib.load(f) for f in self.inputs.variance_files]
+            name_lists = [np.loadtxt(f, str).tolist()
+                          for f in self.inputs.name_files]
 
             # Files are input as a list of 4D images where list entries are
             # runs and the last axis is contrast; we want to concatenate runs
-            # for each contrast, so we need to transpose" the ordering.
-            for con_img, var_img in zip(con_images, var_images):
-                con_frames.append(con_img.get_data()[..., i])
-                var_frames.append(var_img.get_data()[..., i])
+            # for each contrast, so we need to transpose" the ordering
+            # while matching against the list of contrast names for that run.
+            for run, run_names in enumerate(name_lists):
+                con_idx = run_names.index(name)
+                con_frames.append(con_images[run].get_data()[..., con_idx])
+                var_frames.append(var_images[run].get_data()[..., con_idx])
 
             con_data = np.stack(con_frames, axis=-1)
             var_data = np.stack(var_frames, axis=-1)

--- a/lyman/workflows/model.py
+++ b/lyman/workflows/model.py
@@ -520,7 +520,7 @@ class ModelFit(LymanInterface):
 
         # Build the design matrix
         # TODO highpass filter
-        hrf_model = glm.GammaHRF(derivative=False)  # TODO info param
+        hrf_model = glm.GammaHRF(derivative=info.hrf_derivative)
         X = glm.build_design_matrix(design, hrf_model, n_tp=n_tp, tr=info.tr)
 
         # Save out the design matrix

--- a/lyman/workflows/preproc.py
+++ b/lyman/workflows/preproc.py
@@ -1135,10 +1135,8 @@ class RealignmentReport(LymanInterface):
         df = pd.DataFrame(params, columns=cols)
 
         # Plot the motion timeseries
-        params_plot = self.define_output("params_plot", "mc_params.png")
         f = self.plot_motion(df)
-        f.savefig(params_plot, dpi=100)
-        plt.close(f)
+        self.write_visualization("params_plot", "mc_params.png", f)
 
         # Plot the target image
         m = self.plot_target()

--- a/lyman/workflows/tests/test_model.py
+++ b/lyman/workflows/tests/test_model.py
@@ -271,6 +271,7 @@ class TestModelWorkflows(object):
             beta_file=modelfit["beta_file"],
             ols_file=modelfit["ols_file"],
             error_file=modelfit["error_file"],
+            design_file=modelfit["design_file"],
         ).run().outputs
 
         # Test output file names

--- a/lyman/workflows/tests/test_model.py
+++ b/lyman/workflows/tests/test_model.py
@@ -289,6 +289,27 @@ class TestModelWorkflows(object):
         assert nib.load(out.tstat_file).shape[-1] == n_contrasts
         assert len(np.loadtxt(out.name_file, str)) == n_contrasts
 
+    def test_missing_contrasts(self, execdir, modelfit):
+
+        info = deepcopy(modelfit["info"].trait_get())
+        n_contrasts = len(info["contrasts"])
+        info["contrasts"].append(("d", ["d"], [1]))
+
+        out = model.EstimateContrasts(
+            info=info,
+            mask_file=modelfit["mask_file"],
+            beta_file=modelfit["beta_file"],
+            ols_file=modelfit["ols_file"],
+            error_file=modelfit["error_file"],
+            design_file=modelfit["design_file"],
+        ).run().outputs
+
+        # Test output image shapes
+        assert nib.load(out.contrast_file).shape[-1] == n_contrasts
+        assert nib.load(out.variance_file).shape[-1] == n_contrasts
+        assert nib.load(out.tstat_file).shape[-1] == n_contrasts
+        assert len(np.loadtxt(out.name_file, str)) == n_contrasts
+
     def test_model_results(self, execdir, modelres):
 
         out = model.ModelResults(


### PR DESCRIPTION
This PR will port over the remaining code from `moss.glm` while changing how the design matrix construction works in some substantial ways. The main difference is that there won't be a `DesignMatrix` object, instead there will be a function that uses similar rules to build a matrix and then returns a DataFrame. It turns out that many of the bells and whistles of the `moss.glm.DesignMatrix` complicated things but weren't that useful, so in porting to lyman we're going to start with a simpler implementation.

See also https://github.com/mwaskom/moss/issues/21. This PR will handle the sampling resolution issue described there.

This PR also implements tracking of missing contrasts (i.e. contrasts that involve a parameter not included in the design matrix) across processing stages and hence closes #124 