### PR TITLE
Small fixes arising from running lyman on second dataset

### DIFF
--- a/lyman/frontend.py
+++ b/lyman/frontend.py
@@ -200,13 +200,14 @@ def load_scan_info(lyman_dir=None):
     return info
 
 
-def check_extra_vars(module_vars, spec):
+def check_extra_vars(module_vars, spec, kind=None):
     """Raise when unexpected information is defined to avoid errors."""
-    kind = spec.__name__.lower().strip("info")
+    if kind is None:
+        kind = spec.__name__.lower().strip("info")
     extra_vars = set(module_vars) - set(spec().trait_names())
     if extra_vars:
         msg = ("The following variables were unexpectedly present in the "
-               "{} information module: {}".format(kind, extra_vars))
+               "{} information module: {}".format(kind, ", ".join(extra_vars)))
         raise RuntimeError(msg)
 
 
@@ -241,7 +242,7 @@ def info(experiment=None, model=None, lyman_dir=None):
 
     # --- Load project-level information
     project_info = load_info_from_module("project", lyman_dir)
-    check_extra_vars(project_info, ProjectInfo)
+    check_extra_vars(project_info, ProjectInfo, "project")
 
     # Load scan information
     project_info["scan_info"] = load_scan_info(lyman_dir)
@@ -252,7 +253,7 @@ def info(experiment=None, model=None, lyman_dir=None):
     else:
         experiment_info = load_info_from_module(experiment, lyman_dir)
         experiment_info["experiment_name"] = experiment
-        check_extra_vars(experiment_info, ExperimentInfo)
+        check_extra_vars(experiment_info, ModelInfo, "experiment")
 
     # --- Load the model-level information
     if model is None:
@@ -262,7 +263,7 @@ def info(experiment=None, model=None, lyman_dir=None):
             raise RuntimeError("Loading a model requires an experiment")
         model_info = load_info_from_module(experiment + "-" + model, lyman_dir)
         model_info["model_name"] = model
-        check_extra_vars(model_info, ModelInfo)
+        check_extra_vars(model_info, ModelInfo, "model")
 
     # TODO set default single parameter contrasts?
 

--- a/lyman/frontend.py
+++ b/lyman/frontend.py
@@ -195,7 +195,7 @@ def load_scan_info(lyman_dir=None):
 
     scan_fname = op.join(lyman_dir, "scans.yaml")
     with open(scan_fname) as fid:
-        info = yaml.load(fid)
+        info = yaml.load(fid, Loader=yaml.BaseLoader)
 
     return info
 

--- a/lyman/tests/test_frontend.py
+++ b/lyman/tests/test_frontend.py
@@ -33,6 +33,7 @@ class TestFrontend(object):
 
         experiment = dedent("""
         tr = .72
+        smooth_fwhm = 2.5
         """)
 
         model = dedent("""

--- a/lyman/tests/test_frontend.py
+++ b/lyman/tests/test_frontend.py
@@ -37,7 +37,7 @@ class TestFrontend(object):
         """)
 
         model = dedent("""
-        tr = 1.5
+        smooth_fwhm = 4
         contrasts = [("a-b", ["a", "b"], [1, -1])]
         """)
 
@@ -80,9 +80,10 @@ class TestFrontend(object):
 
         info = frontend.info("exp_alpha")
         assert info.tr == .72
+        assert info.smooth_fwhm == 2.5
 
         info = frontend.info("exp_alpha", "model_a")
-        assert info.tr == 1.5
+        assert info.smooth_fwhm == 4
         assert info.contrasts == [("a-b", ["a", "b"], [1, -1])]
 
         with pytest.raises(TraitError):


### PR DESCRIPTION
- Reverse model/experiment spec inheritance to so extraneous info checks are performed correctly (closes #135)
- Use vanilla yaml loader so dates used as session keys stay as strings (closes #136)