### PR TITLE
Don't jacobian modulate topup corrected output

### DIFF
--- a/lyman/workflows/preproc.py
+++ b/lyman/workflows/preproc.py
@@ -733,14 +733,10 @@ class FinalizeUnwarping(LymanInterface):
         corr_img_frames = nib.load(self.inputs.corrected_file)
         corr_data = corr_img_frames.get_data()
 
-        # Jacobian modulate the corrected image
-        corr_mod_data = corr_data * jac_data
-        corr_img_frames = nib.Nifti1Image(corr_mod_data, affine, header)
-
         # Average the corrected image over the final dimension and write
-        corr_mod_data = corr_mod_data.mean(axis=-1)
+        corr_data = corr_data.mean(axis=-1)
         self.write_image("corrected_file", "func.nii.gz",
-                         corr_mod_data, affine, header)
+                         corr_data, affine, header)
 
         # Save the jacobian images using the raw geometry
         self.write_image("jacobian_file", "jacobian.nii.gz",

--- a/lyman/workflows/tests/test_preproc.py
+++ b/lyman/workflows/tests/test_preproc.py
@@ -407,10 +407,9 @@ class TestPreprocWorkflow(object):
         assert np.array_equal(raw_data_out, raw_data[..., 0])
 
         # Test that the corrected image is a temporal average
-        jacobian_data = np.stack(jacobian_data, axis=-1)
-        modulated_data = (corrected_data * jacobian_data).mean(axis=-1)
+        corrected_data = corrected_data.mean(axis=-1)
         corrected_data_out = nib.load(out.corrected_file).get_data()
-        assert np.array_equal(corrected_data_out, modulated_data)
+        assert corrected_data_out == pytest.approx(corrected_data)
 
         # Test that the warp image has the right geometry
         warp_img_out = nib.load(out.warp_file)
@@ -426,6 +425,7 @@ class TestPreprocWorkflow(object):
         assert np.array_equal(warp_mask_out, warp_mask)
 
         # Test that the jacobians have same data but new geomtery
+        jacobian_data = np.stack(jacobian_data, axis=-1)
         jacobian_img_out = nib.load(out.jacobian_file)
         jacobian_data_out = jacobian_img_out.get_data()
         assert np.array_equal(jacobian_img_out.affine, affine)


### PR DESCRIPTION
I haven't verified by reading the TOPUP code but I'm pretty sure this already happens within topup and so doing it again actually decreased corrected image similarity.