### PR TITLE
Handle some TODOs in the model workflow

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -62,6 +62,7 @@ def lyman_info(tmpdir):
         model_name="model_a",
         smooth_fwhm=4,
         surface_smoothing=True,
+        interpolate_noise=True,
         hpf_cutoff=10,
         hrf_derivative=False,
         save_residuals=True,

--- a/lyman/__init__.py
+++ b/lyman/__init__.py
@@ -1,4 +1,10 @@
 from .frontend import *  # flake8: noqa
+from . import glm  # flake8: noqa
+from . import utils # flake8: noqa
+from . import surface  # flake8: noqa
+from . import signals  # flake8: noqa
+from . import workflows  # flake8: noqa
+from . import visualizations  # flake8: noqa
 
 version = "2.0.0.dev"
 __version__ = version

--- a/lyman/frontend.py
+++ b/lyman/frontend.py
@@ -110,10 +110,11 @@ class ModelInfo(HasTraits):
         """),
     )
     interpolate_noise = Bool(
-        True,
+        False,
         desc=dedent("""
         If True, identify locally noisy voxels and replace replace their values
-        using interpolation during spatial filtering.
+        using interpolation during spatial filtering. Warning: this option is
+        still being refined.
         """),
     )
     hpf_cutoff = Either(

--- a/lyman/glm.py
+++ b/lyman/glm.py
@@ -629,6 +629,9 @@ def highpass_filter_matrix(n_tp, cutoff, tr=1):
         Filter matrix.
 
     """
+    if cutoff is None:
+        return np.eye(n_tp)
+
     cutoff = cutoff / tr
     sig2n = np.square(cutoff / np.sqrt(2))
 

--- a/lyman/signals.py
+++ b/lyman/signals.py
@@ -170,7 +170,7 @@ def smooth_volume(data_img, fwhm, mask_img=None, noise_img=None,
     ----------
     data_img : nibabel image
         3D or 4D image data.
-    fwhm : positive float
+    fwhm : positive float or None
         Size of isotropic smoothing kernel in mm.
     mask_img : nibabel image
         3D binary image defining smoothing range.
@@ -186,6 +186,9 @@ def smooth_volume(data_img, fwhm, mask_img=None, noise_img=None,
 
     """
     data = data_img.get_data().astype(np.float, copy=not inplace)
+
+    if fwhm is None or fwhm == 0:
+        return nib.Nifti1Image(data, data_img.affine, data_img.header)
 
     if np.ndim(data) == 3:
         need_squeeze = True
@@ -278,7 +281,7 @@ def smoothing_matrix(measure, vertids, fwhm, exclude=None, minpool=6):
         Object for measuring distance along a cortical mesh.
     vertids : 1d numpy array
         Array of vertex IDs corresponding to each cortical voxel.
-    fwhm : float
+    fwhm : float or None
         Size of the smoothing kernel, in mm.
     exclude : 1d numpy array
         Binary array defining voxels that should be excluded and interpolated
@@ -292,6 +295,10 @@ def smoothing_matrix(measure, vertids, fwhm, exclude=None, minpool=6):
         Matrix with smoothing weights.
 
     """
+    # Handle null smoothing
+    if fwhm is None:
+        return sparse.diags(np.ones_like(vertids)).tocsr()
+
     # Define the weighting function
     if fwhm <= 0:
         raise ValueError("Smoothing kernel fwhm must be positive")

--- a/lyman/signals.py
+++ b/lyman/signals.py
@@ -377,6 +377,12 @@ def smooth_surface(data_img, vert_img, measure, fwhm, noise_img=None,
         Image like ``data_img`` but after smoothing.
 
     """
+    # TODO in vol_to_surf we are using the Freesurfer construct of providing
+    # subject and surface names and using the Freesurfer directory structure
+    # to find files. Is there a compelling reason not to do that here?
+
+    # ---
+
     # Load the data
     data = data_img.get_data().astype(np.float, copy=not inplace)
     vertvol = vert_img.get_data()

--- a/lyman/surface.py
+++ b/lyman/surface.py
@@ -56,6 +56,8 @@ class SurfaceMeasure(object):
         f, v = nib.freesurfer.read_geometry(fname)
         return cls(f, v)
 
+    # TODO add from_names method to load from subject, hemi, surf
+
     def __call__(self, vert, maxdistance=np.inf):
         """Return the distances from input to other vertices.
 

--- a/lyman/tests/test_glm.py
+++ b/lyman/tests/test_glm.py
@@ -492,6 +492,11 @@ class TestHighpassFilter(object):
         # Test row normalization
         assert F.sum(axis=1) == approx(np.zeros(n_tp))
 
+        # Test no filter
+        cutoff = None
+        F = glm.highpass_filter_matrix(n_tp, cutoff, tr)
+        assert np.array_equal(F, np.eye(n_tp))
+
     def test_highpass_filter_spectrum(self, test_data):
 
         orig = test_data["orig"][:, 0]

--- a/lyman/tests/test_signals.py
+++ b/lyman/tests/test_signals.py
@@ -168,7 +168,8 @@ class TestSignals(object):
     def test_smooth_volume_inplace(self, random):
 
         shape = 12, 8, 4
-        data_img = nib.Nifti1Image(random.normal(0, 1, shape), np.eye(4))
+        data = random.normal(0, 1, shape).astype(np.float32)
+        data_img = nib.Nifti1Image(data, np.eye(4))
         out_img = signals.smooth_volume(data_img, 4, inplace=True)
         assert np.array_equal(data_img.get_data(), out_img.get_data())
 
@@ -260,7 +261,7 @@ class TestSignals(object):
 
         sm = surface.SurfaceMeasure(meshdata["verts"], meshdata["faces"])
 
-        data = random.normal(10, 2, shape)
+        data = random.normal(10, 2, shape).astype(np.float32)
         data_img = nib.Nifti1Image(data, affine)
 
         surf_vox = random.choice(np.arange(np.product(shape)), sm.n_v, False)
@@ -305,3 +306,25 @@ class TestSignals(object):
                                          inplace=True)
 
         assert np.array_equal(out_img.get_data(), data)
+
+    def test_load_float_maybe_inplace(self, random):
+
+        dtype = np.float32
+        input_data = random.randn(10).astype(dtype)
+        img = nib.Nifti1Image(input_data, np.eye(4))
+
+        data = signals._load_float_data_maybe_copy(img, True)
+        assert data.dtype == dtype
+        assert data is input_data
+
+        data = signals._load_float_data_maybe_copy(img, False)
+        assert data.dtype == dtype
+        assert data is not input_data
+
+        data = random.randint(0, 1, 10)
+        img = nib.Nifti1Image(data, np.eye(4))
+        data = signals._load_float_data_maybe_copy(img, False)
+        assert data.dtype == np.float
+
+        with pytest.raises(ValueError):
+            data = signals._load_float_data_maybe_copy(img, True)

--- a/lyman/tests/test_signals.py
+++ b/lyman/tests/test_signals.py
@@ -123,6 +123,15 @@ class TestSignals(object):
 
         assert std_4 < std_2 < std_0
 
+    def test_smooth_volume_no_smoothing(self, random):
+
+        shape = 12, 8, 4
+        orig_data = random.normal(0, 1, shape)
+        orig_img = nib.Nifti1Image(orig_data, np.eye(4))
+        new_data = signals.smooth_volume(orig_img, fwhm=None,).get_data()
+
+        assert np.array_equal(orig_data, new_data)
+
     def test_smooth_volume_mask(self, random):
 
         shape = 12, 8, 4
@@ -239,6 +248,10 @@ class TestSignals(object):
         with pytest.raises(RuntimeError):
             signals.smoothing_matrix(sm, vertids, 1)
 
+        # Test null smoothing
+        S = signals.smoothing_matrix(sm, vertids, None)
+        assert np.array_equal(S.toarray(), np.eye(n_vox))
+
     def test_smooth_surface(self, random, meshdata):
 
         shape = 4, 3, 2
@@ -275,8 +288,7 @@ class TestSignals(object):
         assert np.array_equal(out_data[~ribbon], data[~ribbon])
 
         n_tp = shape[-1]
-        noise_vox = surf_vox[0]
-        noise_mask = vertvol == noise_vox
+        noise_mask = vertvol == vertvol.max()
         data[noise_mask] = random.normal(10, 10, n_tp)
         noise_img = nib.Nifti1Image(noise_mask.astype(int), affine)
 

--- a/lyman/workflows/model.py
+++ b/lyman/workflows/model.py
@@ -456,6 +456,7 @@ class ModelFit(LymanInterface):
         # Load the timeseries
         ts_img = nib.load(self.inputs.ts_file)
         affine, header = ts_img.affine, ts_img.header
+        n_tp = ts_img.shape[-1]
 
         # Load the anatomical segmentation and fine analysis mask
         run_mask = nib.load(self.inputs.mask_file).get_data() > 0
@@ -490,7 +491,6 @@ class ModelFit(LymanInterface):
         mean_img = nib.Nifti1Image(mean, affine, header)
 
         # Temporally filter the data
-        n_tp = ts_img.shape[-1]
         hpf_matrix = glm.highpass_filter_matrix(n_tp,
                                                 info.hpf_cutoff,
                                                 info.tr)
@@ -520,9 +520,10 @@ class ModelFit(LymanInterface):
         assert len(design) > 0
 
         # Build the design matrix
-        # TODO highpass filter
         hrf_model = glm.GammaHRF(derivative=info.hrf_derivative)
-        X = glm.build_design_matrix(design, hrf_model, n_tp=n_tp, tr=info.tr)
+        X = glm.build_design_matrix(design, hrf_model,
+                                    n_tp=n_tp, tr=info.tr,
+                                    hpf_matrix=hpf_matrix)
 
         # Save out the design matrix
         design_file = self.define_output("design_file", "design.csv")

--- a/lyman/workflows/model.py
+++ b/lyman/workflows/model.py
@@ -479,8 +479,9 @@ class ModelFit(LymanInterface):
         fwhm = info.smooth_fwhm
 
         # Load the noise segmentation
-        # TODO implement parameterization of noisy voxel removal
-        noise_img = nib.load(self.inputs.noise_file)
+        noise_img = None
+        if info.interpolate_noise:
+            noise_img = nib.load(self.inputs.noise_file)
 
         # Volumetric smoothing
         # TODO use smooth_segmentation instead?

--- a/lyman/workflows/model.py
+++ b/lyman/workflows/model.py
@@ -462,9 +462,15 @@ class ModelFit(LymanInterface):
 
         # Load the anatomical segmentation and fine analysis mask
         run_mask = nib.load(self.inputs.mask_file).get_data() > 0
+
         seg_img = nib.load(self.inputs.seg_file)
         seg = seg_img.get_data()
-        mask = (seg > 0) & (seg < 5) & run_mask
+        gray_seg = (seg > 0) & (seg < 5)
+
+        vert_img = nib.load(self.inputs.surf_file)
+        ribbon = vert_img.get_data().max(axis=-1) > -1
+
+        mask = (ribbon | gray_seg) & run_mask
         n_vox = mask.sum()
         mask_img = nib.Nifti1Image(mask.astype(np.int8), affine, header)
 


### PR DESCRIPTION
A few changes here:

- Fixed smoothing in the model workflow. Previous `inplace` smoothing was silently failing because the images were loaded as `np.float32` and then doing `astype(np.float)` was forcing a copy. Some enhancements / more testing in the signals module and new code in the model workflow address this.
- Fixed (provisionally) the definition of cortical voxels. It turns out that the surface vertex image does not always agree with the nearest-neighbor-resampled wmparc image (generating `seg.nii.gz`), so some voxels with an identified cortical vertex were being considered white matter/out of brain/etc. This needs to be handled upstream, however.
- The logic of not smoothing / filtering is handled within the underlying library functions so that there is less conditional complexity in the workflow code itself.
- Made noise interpolation default to `False` until it can be properly parameterized.