### PR TITLE
Ensure that surface voxels are considered cortical gray matter in segmentation

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -160,6 +160,20 @@ def template(freesurfer):
     reg_file = str(template_dir.join("anat2func.mat"))
     np.savetxt(reg_file, np.random.randn(4, 4))
 
+    lut = pd.DataFrame([
+            ["Unknown", 0, 0, 0, 0],
+            ["Cortical-gray-matter", 59, 95, 138, 255],
+            ["Subcortical-gray-matter", 91, 129, 129, 255],
+            ["Brain-stem", 126, 163, 209, 255],
+            ["Cerebellar-gray-matter", 168, 197, 233, 255],
+            ["Superficial-white-matter", 206, 129, 134, 255],
+            ["Deep-white-matter", 184, 103, 109, 255],
+            ["Cerebellar-white-matter", 155, 78, 73, 255],
+            ["CSF", 251, 221, 122, 255]
+        ])
+    lut_file = str(template_dir.join("seg.lut"))
+    lut.to_csv(lut_file, sep="\t", header=False, index=True)
+
     seg_data = rs.randint(0, 7, vol_shape)
     seg_file = str(template_dir.join("seg.nii.gz"))
     nib.save(nib.Nifti1Image(seg_data, affine), seg_file)
@@ -192,8 +206,9 @@ def template(freesurfer):
     freesurfer.update(
         vol_shape=vol_shape,
         subject=subject,
-        reg_file=reg_file,
+        lut_file=lut_file,
         seg_file=seg_file,
+        reg_file=reg_file,
         anat_file=anat_file,
         mask_file=mask_file,
         surf_file=surf_file,

--- a/conftest.py
+++ b/conftest.py
@@ -84,6 +84,7 @@ def lyman_info(tmpdir):
         subject_dir = data_dir.mkdir(subject)
         subject_dir.mkdir("mri")
         subject_dir.mkdir("surf")
+        subject_dir.mkdir("label")
         subject_dir.mkdir("func")
         design_dir = subject_dir.mkdir("design")
         design.to_csv(design_dir.join("model_a.csv"))
@@ -111,6 +112,7 @@ def freesurfer(lyman_info):
 
     subject = "subj01"
     mri_dir = lyman_info["data_dir"].join(subject).join("mri")
+    label_dir = lyman_info["data_dir"].join(subject).join("label")
 
     seed = sum(map(ord, "freesurfer"))
     rs = np.random.RandomState(seed)
@@ -131,11 +133,21 @@ def freesurfer(lyman_info):
     wmparc_file = str(mri_dir.join("wmparc.mgz"))
     nib.save(nib.MGHImage(wmparc_data.astype("int16"), affine), wmparc_file)
 
+    n = 10
+    fmt = ["%d", "%.3f", "%.3f", "%.3f", "%.9f"]
+    label_data = np.c_[np.arange(n), np.zeros((n, 4))]
+    label_files = {}
+    for hemi in ["lh", "rh"]:
+        fname = str(label_dir.join("{}.cortex.label".format(hemi)))
+        label_files[hemi] = fname
+        np.savetxt(fname, label_data, fmt=fmt, header=str(n))
+
     lyman_info.update(
         subject=subject,
         norm_file=norm_file,
         orig_file=orig_file,
         wmparc_file=wmparc_file,
+        label_files=label_files,
     )
     return lyman_info
 

--- a/lyman/workflows/model.py
+++ b/lyman/workflows/model.py
@@ -461,18 +461,14 @@ class ModelFit(LymanInterface):
         n_tp = ts_img.shape[-1]
 
         # Load the anatomical segmentation and fine analysis mask
-        run_mask = nib.load(self.inputs.mask_file).get_data() > 0
-
         seg_img = nib.load(self.inputs.seg_file)
+        mask_img = nib.load(self.inputs.mask_file)
+
         seg = seg_img.get_data()
-        gray_seg = (seg > 0) & (seg < 5)
-
-        vert_img = nib.load(self.inputs.surf_file)
-        ribbon = vert_img.get_data().max(axis=-1) > -1
-
-        mask = (ribbon | gray_seg) & run_mask
-        n_vox = mask.sum()
+        mask = mask_img.get_data()
+        mask = (mask > 0) & (seg > 0) & (seg < 5)
         mask_img = nib.Nifti1Image(mask.astype(np.int8), affine, header)
+        n_vox = mask.sum()
 
         # --- Spatial filtering
 

--- a/lyman/workflows/tests/test_template.py
+++ b/lyman/workflows/tests/test_template.py
@@ -57,6 +57,7 @@ class TestTemplateWorkflow(object):
     def test_anatomical_segmentation(self, execdir, template):
 
         out = AnatomicalSegmentation(
+            anat_file=template["anat_file"],
             surf_file=template["surf_file"],
             wmparc_file=template["wmparc_file"],
         ).run().outputs
@@ -65,9 +66,11 @@ class TestTemplateWorkflow(object):
         assert out.seg_file == execdir.join("seg.nii.gz")
         assert out.mask_file == execdir.join("mask.nii.gz")
 
+        # Test size of the lookup table
         lut = pd.read_csv(out.lut_file, sep="\t", header=None)
         assert lut.shape == (9, 6)
 
+        # Test that the segmentation cortical gray matches surface vertices
         seg = nib.load(out.seg_file).get_data()
         surf = (nib.load(template["surf_file"]).get_data() > -1).any(axis=-1)
         assert np.all(seg[surf] == 1)


### PR DESCRIPTION
- Ensure that surface voxels are considered cortical gray matter in segmentation (closes #151)
- Write out a Freeview-style color lookup table for the segmentation volume
- Exclude voxels from the surface vertex image using the Freesurfer cortex label