### PR TITLE
Improve surface smoothing and other surface operations

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -424,13 +424,12 @@ def meshdata(execdir):
                  4: {2: sqrt3, 3: sqrt8}}
 
     subj = "subj01"
-    hemi = "lh"
     surf = "white"
 
-    fname = str(execdir.mkdir(subj)
-                       .mkdir("surf")
-                       .join("{}.{}".format(hemi, surf)))
-    nib.freesurfer.write_geometry(fname, verts, faces)
+    surf_dir = execdir.mkdir(subj).mkdir("surf")
+    for hemi in ["lh", "rh"]:
+        fname = str(surf_dir.join("{}.{}".format(hemi, surf)))
+        nib.freesurfer.write_geometry(fname, verts, faces)
 
     meshdata = dict(
         verts=verts,
@@ -438,8 +437,8 @@ def meshdata(execdir):
         neighbors=neighbors,
         fname=fname,
         subj=subj,
-        hemi=hemi,
         surf=surf,
+        hemi=hemi,
     )
 
     orig_subjects_dir = os.environ.get("SUBJECTS_DIR", None)

--- a/conftest.py
+++ b/conftest.py
@@ -423,7 +423,13 @@ def meshdata(execdir):
                  3: {0: 2.0, 2: sqrt3, 4: sqrt8},
                  4: {2: sqrt3, 3: sqrt8}}
 
-    fname = execdir.join("test.mesh")
+    subj = "subj01"
+    hemi = "lh"
+    surf = "white"
+
+    fname = str(execdir.mkdir(subj)
+                       .mkdir("surf")
+                       .join("{}.{}".format(hemi, surf)))
     nib.freesurfer.write_geometry(fname, verts, faces)
 
     meshdata = dict(
@@ -431,5 +437,17 @@ def meshdata(execdir):
         faces=faces,
         neighbors=neighbors,
         fname=fname,
+        subj=subj,
+        hemi=hemi,
+        surf=surf,
     )
-    return meshdata
+
+    orig_subjects_dir = os.environ.get("SUBJECTS_DIR", None)
+    os.environ["SUBJECTS_DIR"] = str(execdir)
+
+    yield meshdata
+
+    if orig_subjects_dir is None:
+        del os.environ["SUBJECTS_DIR"]
+    else:
+        os.environ["SUBJECTS_DIR"] = orig_subjects_dir

--- a/lyman/signals.py
+++ b/lyman/signals.py
@@ -172,7 +172,8 @@ def smooth_volume(data_img, fwhm, mask_img=None, noise_img=None,
     data_img : nibabel image
         3D or 4D image data.
     fwhm : positive float or None
-        Size of isotropic smoothing kernel in mm.
+        Size of isotropic smoothing kernel, in mm, or None to return input
+        (as float and possibly copied).
     mask_img : nibabel image
         3D binary image defining smoothing range.
     noise_img : nibabel image
@@ -234,8 +235,9 @@ def smooth_segmentation(data_img, seg_img, fwhm, noise_img=None,
         3D or 4D image data.
     seg_img : nibabel image
         3D label image defining smoothing ranges.
-    fwhm : positive float
-        Size of isotropic smoothing kernel in mm.
+    fwhm : positive float or None
+        Size of isotropic smoothing kernel, in mm, or None to return input
+        (as float and possibly copied).
     noise_img : nibabel image
         3D binary image defining voxels to be interpolated out.
     inplace : bool
@@ -282,8 +284,8 @@ def smoothing_matrix(measure, vertids, fwhm, exclude=None, minpool=6):
         Object for measuring distance along a cortical mesh.
     vertids : 1d numpy array
         Array of vertex IDs corresponding to each cortical voxel.
-    fwhm : float or None
-        Size of the smoothing kernel, in mm.
+    fwhm : positive float or None
+        Size of the smoothing kernel, in mm, or None to return identity matrix.
     exclude : 1d numpy array
         Binary array defining voxels that should be excluded and interpolated
         during smoothing.
@@ -364,8 +366,9 @@ def smooth_surface(data_img, vert_img, fwhm, subject, surf="graymid",
         Image where voxels have their corresponding surfave vertex ID or are -1
         if they do not correspond to cortex. The first frame should have left
         hemisphere vertices and the second right hemisphere vertices.
-    fwhm : float
-        Size of smoothing kernel in mm.
+    fwhm : positive float or None
+        Size of isotropic smoothing kernel, in mm, or None to return input
+        (as float and possibly copied).
     subject : string
         Subject ID to locate data in data directory.
     surf : string

--- a/lyman/signals.py
+++ b/lyman/signals.py
@@ -224,7 +224,7 @@ def smooth_volume(data_img, fwhm, mask_img=None, noise_img=None,
     return nib.Nifti1Image(data, data_img.affine, data_img.header)
 
 
-def smooth_segmentation(data_img, fwhm, seg_img, noise_img=None,
+def smooth_segmentation(data_img, seg_img, fwhm, noise_img=None,
                         inplace=False):
     """Filter each compartment of a segmentation with an isotropic gaussian.
 
@@ -232,10 +232,10 @@ def smooth_segmentation(data_img, fwhm, seg_img, noise_img=None,
     ----------
     data_img : nibabel image
         3D or 4D image data.
-    fwhm : positive float
-        Size of isotropic smoothing kernel in mm.
     seg_img : nibabel image
         3D label image defining smoothing ranges.
+    fwhm : positive float
+        Size of isotropic smoothing kernel in mm.
     noise_img : nibabel image
         3D binary image defining voxels to be interpolated out.
     inplace : bool
@@ -352,8 +352,8 @@ def smoothing_matrix(measure, vertids, fwhm, exclude=None, minpool=6):
     return S.tocsr()
 
 
-def smooth_surface(data_img, vert_img, surf, subject, fwhm, noise_img=None,
-                   inplace=False, subjects_dir=None):
+def smooth_surface(data_img, vert_img, fwhm, subject, surf="graymid",
+                   noise_img=None, inplace=False, subjects_dir=None):
     """Smooth cortical voxels with Gaussian weighted surface distances.
 
     Parameters
@@ -364,12 +364,12 @@ def smooth_surface(data_img, vert_img, surf, subject, fwhm, noise_img=None,
         Image where voxels have their corresponding surfave vertex ID or are -1
         if they do not correspond to cortex. The first frame should have left
         hemisphere vertices and the second right hemisphere vertices.
-    surf : string
-        Name of the surface defining the mesh geometry.
-    subject : string
-        Subject ID to locate data in data directory.
     fwhm : float
         Size of smoothing kernel in mm.
+    subject : string
+        Subject ID to locate data in data directory.
+    surf : string
+        Name of the surface defining the mesh geometry.
     noise_img : nibabel image
         Binary image defining voxels that should be interpolated out.
     inplace :bool

--- a/lyman/surface.py
+++ b/lyman/surface.py
@@ -56,7 +56,13 @@ class SurfaceMeasure(object):
         f, v = nib.freesurfer.read_geometry(fname)
         return cls(f, v)
 
-    # TODO add from_names method to load from subject, hemi, surf
+    @classmethod
+    def from_names(cls, subj, hemi, surf, subjects_dir=None):
+        """Initialize from Freesurfer-style names."""
+        if subjects_dir is None:
+            subjects_dir = os.environ["SUBJECTS_DIR"]
+        fname = op.join(subjects_dir, subj, "surf", "{}.{}".format(hemi, surf))
+        return cls.from_file(fname)
 
     def __call__(self, vert, maxdistance=np.inf):
         """Return the distances from input to other vertices.

--- a/lyman/surface.py
+++ b/lyman/surface.py
@@ -112,7 +112,7 @@ class SurfaceMeasure(object):
         return f_dist
 
 
-def vol_to_surf(data_img, hemi, surf, subject,
+def vol_to_surf(data_img, subject, hemi, surf="graymid",
                 null_value=0, subjects_dir=None):
     """Sample data from a volume image onto a surface mesh.
 
@@ -123,12 +123,12 @@ def vol_to_surf(data_img, hemi, surf, subject,
     ----------
     data_img : nibabel image
         Input volume image; can be 3D or 4D.
+    subject : string
+        Subject ID to locate data in data directory.
     hemi : lh | rh
         Hemisphere code; with ``surf`` finds surface mesh geometry file.
     surf : string
         Surface name, with ``hemi`` finds surface mesh geometry file.
-    subject : string
-        Subject ID to locate data in data directory.
     null_value : float
         Value to use for surface vertices that are outside the volume field
         of view.

--- a/lyman/tests/test_signals.py
+++ b/lyman/tests/test_signals.py
@@ -181,7 +181,7 @@ class TestSignals(object):
         data_img = nib.Nifti1Image(data, np.eye(4))
         seg_img = nib.Nifti1Image(seg, np.eye(4))
 
-        out_img = signals.smooth_segmentation(data_img, 4, seg_img)
+        out_img = signals.smooth_segmentation(data_img, seg_img, 4)
         assert out_img.get_data() == pytest.approx(data.astype(np.float))
 
     def test_smooth_segmentation_inplace(self, random):
@@ -194,7 +194,7 @@ class TestSignals(object):
         data_img = nib.Nifti1Image(data, np.eye(4))
         seg_img = nib.Nifti1Image(seg, np.eye(4))
 
-        out_img = signals.smooth_segmentation(data_img, 4, seg_img,
+        out_img = signals.smooth_segmentation(data_img, seg_img, 4,
                                               inplace=True)
         assert np.array_equal(out_img.get_data(), data.astype(np.float))
 
@@ -274,7 +274,7 @@ class TestSignals(object):
         ribbon = (vertvol > -1).any(axis=-1)
 
         out_img = signals.smooth_surface(
-            data_img, vert_img, surf, subject, fwhm
+            data_img, vert_img, fwhm, subject, surf,
         )
         out_data = out_img.get_data()
 
@@ -287,7 +287,7 @@ class TestSignals(object):
         data_img = nib.Nifti1Image(data, affine)
 
         out_img = signals.smooth_surface(
-            data_img, vert_img, surf, subject, fwhm
+            data_img, vert_img, fwhm, subject, surf,
         )
         out_data = out_img.get_data()
 
@@ -300,10 +300,10 @@ class TestSignals(object):
         noise_img = nib.Nifti1Image(noise_mask.astype(int), affine)
 
         noise_out_img = signals.smooth_surface(
-            data_img, vert_img, surf, subject, fwhm
+            data_img, vert_img, fwhm, subject, surf,
         )
         clean_out_img = signals.smooth_surface(
-            data_img, vert_img, surf, subject, fwhm, noise_img
+            data_img, vert_img, fwhm, subject, surf, noise_img
         )
 
         noise_sd = noise_out_img.get_data()[noise_mask].std()
@@ -312,7 +312,7 @@ class TestSignals(object):
         assert clean_sd < noise_sd
 
         out_img = signals.smooth_surface(
-            data_img, vert_img, surf, subject, fwhm, inplace=True
+            data_img, vert_img, fwhm, subject, surf, inplace=True
         )
 
         assert np.array_equal(out_img.get_data(), data)
@@ -320,7 +320,7 @@ class TestSignals(object):
         with pytest.raises(ValueError):
             vert_img = nib.Nifti1Image(vertvol[..., 0], affine)
             out_img = signals.smooth_surface(
-                data_img, vert_img, surf, subject, fwhm,
+                data_img, vert_img, fwhm, subject, surf,
             )
 
     def test_load_float_maybe_inplace(self, random):

--- a/lyman/tests/test_surface.py
+++ b/lyman/tests/test_surface.py
@@ -71,13 +71,13 @@ class TestVolToSurf(object):
         n_frames = vert_img.shape[-1]
 
         surf_data = surface.vol_to_surf(
-            anat_img, "lh", template["mesh_name"], template["subject"],
+            anat_img, template["subject"], "lh", template["mesh_name"],
         )
 
         assert surf_data.shape == (n_verts,)
 
         surf_data = surface.vol_to_surf(
-            vert_img, "lh", template["mesh_name"], template["subject"],
+            vert_img, template["subject"], "lh", template["mesh_name"],
         )
 
         assert surf_data.shape == (n_verts, n_frames)

--- a/lyman/tests/test_surface.py
+++ b/lyman/tests/test_surface.py
@@ -20,6 +20,15 @@ class TestSurfaceMeasure(object):
         for v, v_n in sm.neighbors.items():
             assert v_n == pytest.approx(meshdata["neighbors"][v])
 
+    def test_surface_measure_neighbors_from_names(self, meshdata):
+
+        sm = surface.SurfaceMeasure.from_names(
+            meshdata["subj"], meshdata["hemi"], meshdata["surf"]
+        )
+
+        for v, v_n in sm.neighbors.items():
+            assert v_n == pytest.approx(meshdata["neighbors"][v])
+
     def test_surface_measure_distance(self, meshdata):
 
         sm = surface.SurfaceMeasure(meshdata["verts"], meshdata["faces"])

--- a/lyman/visualizations.py
+++ b/lyman/visualizations.py
@@ -605,7 +605,7 @@ class CarpetPlot(object):
     def setup_figure(self):
         """Initialize and organize the matplotlib objects."""
         width, height = 8, 10
-        f = plt.figure(figsize=(width, height), facecolor="0")
+        f = plt.figure(figsize=(width, height))
 
         gs = plt.GridSpec(nrows=2, ncols=2,
                           left=.07, right=.98,

--- a/lyman/workflows/model.py
+++ b/lyman/workflows/model.py
@@ -468,8 +468,8 @@ class ModelFit(LymanInterface):
             noise_img = nib.load(self.inputs.noise_file)
 
         # Volumetric smoothing
-        # TODO use smooth_segmentation instead?
-        filt_img = signals.smooth_volume(ts_img, fwhm, mask_img, noise_img)
+        filt_img = signals.smooth_segmentation(ts_img, seg_img,
+                                               fwhm, noise_img)
 
         # Cortical manifold smoothing
         if info.surface_smoothing:

--- a/lyman/workflows/model.py
+++ b/lyman/workflows/model.py
@@ -475,10 +475,9 @@ class ModelFit(LymanInterface):
         if info.surface_smoothing:
 
             vert_img = nib.load(self.inputs.surf_file)
-
             signals.smooth_surface(
-                ts_img, vert_img, "graymid", subject,
-                fwhm, noise_img, inplace=True,
+                ts_img, vert_img, fwhm, subject,
+                noise_img=noise_img, inplace=True,
             )
 
             ribbon = vert_img.get_data().max(axis=-1) > -1

--- a/lyman/workflows/template.py
+++ b/lyman/workflows/template.py
@@ -255,7 +255,7 @@ class AnatomicalSegmentation(LymanInterface):
         fs_data = fs_img.get_data()
 
         # Remap the wmparc ids to more general classifications
-        seg_data = np.zeros_like(fs_data)
+        seg_data = np.zeros_like(fs_data, np.int8)
 
         seg_ids = [
             np.arange(1000, 3000),  # Cortical gray matter

--- a/lyman/workflows/tests/test_model.py
+++ b/lyman/workflows/tests/test_model.py
@@ -170,7 +170,6 @@ class TestModelWorkflows(object):
         out = model.ModelFitInput(
             experiment=exp_name,
             model=model_name,
-            data_dir=str(timeseries["data_dir"]),
             proc_dir=str(timeseries["proc_dir"]),
             subject=subject,
             run_tuple=run_tuple,
@@ -185,7 +184,6 @@ class TestModelWorkflows(object):
         assert out.ts_file == timeseries["ts_file"]
         assert out.noise_file == timeseries["noise_file"]
         assert out.mc_file == timeseries["mc_file"]
-        assert out.mesh_files == timeseries["mesh_files"]
         assert out.output_path == timeseries["model_dir"]
 
     def test_model_results_input(self, modelfit):
@@ -228,7 +226,6 @@ class TestModelWorkflows(object):
             mask_file=timeseries["mask_file"],
             noise_file=timeseries["noise_file"],
             mc_file=timeseries["mc_file"],
-            mesh_files=timeseries["mesh_files"],
         ).run().outputs
 
         # Test output file names

--- a/lyman/workflows/tests/test_template.py
+++ b/lyman/workflows/tests/test_template.py
@@ -69,16 +69,15 @@ class TestTemplateWorkflow(object):
         assert out.seg_file == execdir.join("seg.nii.gz")
         assert out.mask_file == execdir.join("mask.nii.gz")
 
-        # Test that segmentation is integer typed
-        seg_img = nib.load(out.seg_file)
-        assert np.issubdtype(seg_img.header.get_data_dtype(), "uint8")
-
         # Test size of the lookup table
         lut = pd.read_csv(out.lut_file, sep="\t", header=None)
         assert lut.shape == (9, 6)
 
+        # Test that segmentation is integer typed
+        seg = nib.load(out.seg_file).get_data()
+        assert np.array_equal(seg, seg.astype("uint8"))
+
         # Test that the segmentation cortical gray matches surface vertices
-        seg = seg_img.get_data()
         surf = (nib.load(template["surf_file"]).get_data() > -1).any(axis=-1)
         assert np.all(seg[surf] == 1)
 

--- a/lyman/workflows/tests/test_template.py
+++ b/lyman/workflows/tests/test_template.py
@@ -69,12 +69,16 @@ class TestTemplateWorkflow(object):
         assert out.seg_file == execdir.join("seg.nii.gz")
         assert out.mask_file == execdir.join("mask.nii.gz")
 
+        # Test that segmentation is integer typed
+        seg_img = nib.load(out.seg_file)
+        assert np.issubdtype(seg_img.header.get_data_dtype(), "uint8")
+
         # Test size of the lookup table
         lut = pd.read_csv(out.lut_file, sep="\t", header=None)
         assert lut.shape == (9, 6)
 
         # Test that the segmentation cortical gray matches surface vertices
-        seg = nib.load(out.seg_file).get_data()
+        seg = seg_img.get_data()
         surf = (nib.load(template["surf_file"]).get_data() > -1).any(axis=-1)
         assert np.all(seg[surf] == 1)
 


### PR DESCRIPTION
- Have surface smoothing take subject/surface parameters instead of a `SurfaceMeasure` object.
- Operate on both hemispheres in one call.
- Fix segmentation to preserve integer datatype.
- Standardize order of surface parameters across functions.
- Change model workflow to use `smooth_segmentation` for volumetric smoothing.