### PR TITLE
Add FIR model basis set as HRF

### DIFF
--- a/lyman/glm.py
+++ b/lyman/glm.py
@@ -145,9 +145,7 @@ class FIRBasis(HRFModel):
             Output data; has same type of input but will have multiple columns.
 
         """
-        # TODO implement offset
         row = signal.unit_impulse(self.n, 0)
-
         full_input = np.concatenate([input, np.zeros(self.offset)])
         basis = linalg.toeplitz(full_input, row)[self.offset:]
 


### PR DESCRIPTION
Add an FIR model that transforms an input into an FIR basis:

```python
x = pd.Series(np.zeros(30), name="event")
x[[1, 10, 18, 24]] = 1
basis = lyman.glm.FIRBasis(n=12).transform(x)
f, ax = plt.subplots(figsize=(4, 8))
sns.heatmap(basis, cbar=False)
```
![image](https://user-images.githubusercontent.com/315810/44004811-e003a0bc-9e36-11e8-905d-f2ffdd8bbf10.png)

This builds a toeplitz matrix, so any kind of input should work (not just delta functions):

```python
x = pd.Series(np.random.randn(30), name="norm")
basis = lyman.glm.FIRBasis(n=12).transform(x)
f, ax = plt.subplots(figsize=(4, 8))
sns.heatmap(basis, cbar=False, center=0)
```
![image](https://user-images.githubusercontent.com/315810/44004819-1b44e9ec-9e37-11e8-954c-a8f6584d5576.png)


This can be used externally, but is not incorporated into the workflows (yet: #168)

Also implementing this showed that the current way `GammaHRF` is implemented (optionally returning a tuple) is a pain, and should be improved (#165)