### PR TITLE
Fix HRF convolution

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ before_install:
   - conda update -q conda
   - conda config --add channels conda-forge 
   - conda info -a
-  - cp testing/matplotlibrc .
 
 install:
   - conda create -q -n testenv pip python=$TRAVIS_PYTHON_VERSION

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 export SHELL := /bin/bash
+export MPLBACKEND := Agg
 
 test:
 

--- a/lyman/glm.py
+++ b/lyman/glm.py
@@ -196,15 +196,15 @@ def condition_to_regressors(name, condition, hrf_model,
 
     # Define hires and output resolution timepoints
     # TODO should output timepoints reflect shifting or not?
-    hires_tps = np.arange(0, n_tp * tr, tr / res)
+    hires_tps = np.arange(0, n_tp * tr + tr, 1 / res)
     tps = np.arange(0, n_tp * tr, tr)
 
     # Initialize the array that will be transformed
     hires_input = np.zeros_like(hires_tps, np.float)
 
     # Determine the time points at which each even starts and stops
-    onset_at = np.round(onset / (tr / res)).astype(int)
-    offset_at = np.round((onset + duration) / (tr / res)).astype(int)
+    onset_at = np.round(onset * res).astype(int)
+    offset_at = np.round((onset + duration) * res).astype(int)
 
     # Insert specified amplitudes for each event duration
     for start, end, value in zip(onset_at, offset_at, value):

--- a/lyman/tests/test_glm.py
+++ b/lyman/tests/test_glm.py
@@ -303,6 +303,25 @@ class TestDesignMatrix(object):
         X2 = glm.build_design_matrix(conditions[min_cols].copy(), n_tp=48)
         assert np.array_equal(X1.values, X2.values)
 
+    @pytest.mark.parametrize(
+        "tr,res",
+        product((.1, .5, 1, 1.5, 2), (60, 30, 1)))
+    def test_tr_and_sampling(self, tr, res):
+
+        condition = pd.DataFrame(dict(
+            onset=[2],
+            value=[1],
+            duration=[0],
+        ))
+
+        hrf = glm.GammaHRF(res=res)
+
+        out, *_ = glm.condition_to_regressors(
+            "test", condition, hrf, 30 / tr, tr, res, 0
+        )
+
+        assert 7 <= out.idxmax() <= 8
+
 
 class TestContrastMatrix(object):
 

--- a/lyman/workflows/tests/test_model.py
+++ b/lyman/workflows/tests/test_model.py
@@ -147,7 +147,7 @@ class TestModelWorkflows(object):
         model_name = "model_alpha"
 
         ifc = model.ModelResultsPath(
-            proc_dir=proc_dir,
+            proc_dir=str(proc_dir),
             subject=subject,
             experiment=experiment,
             model=model_name,
@@ -218,7 +218,7 @@ class TestModelWorkflows(object):
             subject=timeseries["subject"],
             session=timeseries["session"],
             run=timeseries["run"],
-            data_dir=timeseries["data_dir"],
+            data_dir=str(timeseries["data_dir"]),
             info=timeseries["info"].trait_get(),
             seg_file=timeseries["seg_file"],
             surf_file=timeseries["surf_file"],

--- a/lyman/workflows/tests/test_preproc.py
+++ b/lyman/workflows/tests/test_preproc.py
@@ -176,8 +176,8 @@ class TestPreprocWorkflow(object):
 
         out = preproc.RunInput(
             run=run_tuple,
-            data_dir=template["data_dir"],
-            proc_dir=template["proc_dir"],
+            data_dir=str(template["data_dir"]),
+            proc_dir=str(template["proc_dir"]),
             experiment=exp_name,
             sb_template=sb_template,
             ts_template=template["info"].ts_template,
@@ -264,8 +264,8 @@ class TestPreprocWorkflow(object):
 
         out = preproc.SessionInput(
             session=session_tuple,
-            data_dir=template["data_dir"],
-            proc_dir=template["proc_dir"],
+            data_dir=str(template["data_dir"]),
+            proc_dir=str(template["proc_dir"]),
             fm_template=fm_template,
             phase_encoding=phase_encoding,
         ).run().outputs
@@ -316,8 +316,8 @@ class TestPreprocWorkflow(object):
         phase_encoding = phase_encoding[::-1]
         out = preproc.SessionInput(
             session=session_tuple,
-            data_dir=template["data_dir"],
-            proc_dir=template["proc_dir"],
+            data_dir=str(template["data_dir"]),
+            proc_dir=str(template["proc_dir"]),
             fm_template=fm_template,
             phase_encoding=phase_encoding,
         ).run().outputs
@@ -707,7 +707,7 @@ class TestPreprocWorkflow(object):
         out = preproc.AnatRegReport(
             subject_id=subject_id,
             session_tuple=session_tuple,
-            data_dir=data_dir,
+            data_dir=str(data_dir),
             in_file=in_file,
             cost_file=cost_file,
         ).run().outputs

--- a/lyman/workflows/tests/test_template.py
+++ b/lyman/workflows/tests/test_template.py
@@ -46,7 +46,7 @@ class TestTemplateWorkflow(object):
     def test_template_input(self, freesurfer):
 
         out = TemplateInput(
-            data_dir=freesurfer["data_dir"],
+            data_dir=str(freesurfer["data_dir"]),
             subject=freesurfer["subject"]
         ).run().outputs
 

--- a/testing/matplotlibrc
+++ b/testing/matplotlibrc
@@ -1,1 +1,0 @@
-backend: Agg


### PR DESCRIPTION
Fixes a nasty bug introduced in #171.

I am not certain that the new logic of HRF convolution is spelled out anywhere. It took me a while to reconstruct my original intentions, which were violated by the change in #171. The basic idea is that `res` should be interpreted as in Hz (not as an upscaling factor, as in FSL and originally in lyman). Therefore, the sampling of the `hires_tps` should be independent of the TR.

This fixes the problem and adds a test that should catch related issues.