### PR TITLE
Improve and enhance HRF basis model

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -54,6 +54,7 @@ HRF models
 
     glm.HRFModel
     glm.GammaHRF
+    glm.GammaBasis
     glm.FIRBasis
     glm.IdentityHRF
 

--- a/lyman/workflows/model.py
+++ b/lyman/workflows/model.py
@@ -603,7 +603,8 @@ class ModelFit(LymanInterface):
         ], axis=1).dropna()
 
         # Build the full design matrix
-        hrf_model = glm.GammaHRF(derivative=info.hrf_derivative)
+        hrf_model = glm.GammaBasis(time_derivative=info.hrf_derivative,
+                                   disp_derivative=False)  # TODO?
         X = glm.build_design_matrix(design, hrf_model,
                                     regressors=regressors,
                                     n_tp=n_tp, tr=info.tr,


### PR DESCRIPTION
- Add new `glm.GammaBasis` class for informed basis set model
- Add dispersion derivative to `glm.GammaBasis` (but not used in lyman workflows)
- Orthogonalize predicted responses for the derivative regressors w/r/t main regressor
- Simplify output of `glm.GammaHRF`
- Change parameter name of `HRFModel.transform` to avoid collusion with built-in